### PR TITLE
Replace the print statement by the print() function #PEP3105

### DIFF
--- a/examples/ex_01.py
+++ b/examples/ex_01.py
@@ -15,7 +15,7 @@ def main():
     
     stix_package_two = STIXPackage.from_dict(stix_dict) # create python-stix object from dictionary
     xml = stix_package_two.to_xml() # generate xml from python-stix object
-    print xml
+    print(xml)
     
 if __name__ == '__main__':
     main()

--- a/stix/bindings/capec/ap_schema_2_5.py
+++ b/stix/bindings/capec/ap_schema_2_5.py
@@ -16334,7 +16334,7 @@ Usage: python <Parser>.py [ -s ] <in_xml_file>
 """
 
 def usage():
-    print USAGE_TEXT
+    print(USAGE_TEXT)
     sys.exit(1)
 
 

--- a/stix/bindings/cvrf/cvrf_typed.py
+++ b/stix/bindings/cvrf/cvrf_typed.py
@@ -10762,7 +10762,7 @@ Usage: python <Parser>.py [ -s ] <in_xml_file>
 """
 
 def usage():
-    print USAGE_TEXT
+    print(USAGE_TEXT)
     sys.exit(1)
 
 

--- a/stix/bindings/data_marking_0_5.py
+++ b/stix/bindings/data_marking_0_5.py
@@ -845,7 +845,7 @@ Usage: python <Parser>.py [ -s ] <in_xml_file>
 """
 
 def usage():
-    print USAGE_TEXT
+    print(USAGE_TEXT)
     sys.exit(1)
 
 def get_root_tag(node):

--- a/stix/bindings/iodef/iodef_1_0.py
+++ b/stix/bindings/iodef/iodef_1_0.py
@@ -5528,7 +5528,7 @@ Usage: python <Parser>.py [ -s ] <in_xml_file>
 """
 
 def usage():
-    print USAGE_TEXT
+    print(USAGE_TEXT)
     sys.exit(1)
 
 

--- a/stix/bindings/oasis/xal.py
+++ b/stix/bindings/oasis/xal.py
@@ -5678,7 +5678,7 @@ Usage: python <Parser>.py [ -s ] <in_xml_file>
 """
 
 def usage():
-    print USAGE_TEXT
+    print(USAGE_TEXT)
     sys.exit(1)
 
 

--- a/stix/bindings/oasis/xpil.py
+++ b/stix/bindings/oasis/xpil.py
@@ -20980,7 +20980,7 @@ Usage: python <Parser>.py [ -s ] <in_xml_file>
 """
 
 def usage():
-    print USAGE_TEXT
+    print(USAGE_TEXT)
     sys.exit(1)
 
 

--- a/stix/bindings/stix_campaign_0_5_1.py
+++ b/stix/bindings/stix_campaign_0_5_1.py
@@ -2452,7 +2452,7 @@ Usage: python <Parser>.py [ -s ] <in_xml_file>
 """
 
 def usage():
-    print USAGE_TEXT
+    print(USAGE_TEXT)
     sys.exit(1)
 
 def get_root_tag(node):

--- a/stix/bindings/stix_coa_0_3_1.py
+++ b/stix/bindings/stix_coa_0_3_1.py
@@ -1126,7 +1126,7 @@ Usage: python <Parser>.py [ -s ] <in_xml_file>
 """
 
 def usage():
-    print USAGE_TEXT
+    print(USAGE_TEXT)
     sys.exit(1)
 
 def get_root_tag(node):

--- a/stix/bindings/stix_common_0_2.py
+++ b/stix/bindings/stix_common_0_2.py
@@ -2372,7 +2372,7 @@ Usage: python <Parser>.py [ -s ] <in_xml_file>
 """
 
 def usage():
-    print USAGE_TEXT
+    print(USAGE_TEXT)
     sys.exit(1)
 
 def get_root_tag(node):

--- a/stix/bindings/stix_core_1_0.py
+++ b/stix/bindings/stix_core_1_0.py
@@ -1367,7 +1367,7 @@ Usage: python <Parser>.py [ -s ] <in_xml_file>
 """
 
 def usage():
-    print USAGE_TEXT
+    print(USAGE_TEXT)
     sys.exit(1)
 
 def get_root_tag(node):

--- a/stix/bindings/stix_exploit_target_0_3_1.py
+++ b/stix/bindings/stix_exploit_target_0_3_1.py
@@ -971,7 +971,7 @@ Usage: python <Parser>.py [ -s ] <in_xml_file>
 """
 
 def usage():
-    print USAGE_TEXT
+    print(USAGE_TEXT)
     sys.exit(1)
 
 def get_root_tag(node):

--- a/stix/bindings/stix_incident_0_3_1.py
+++ b/stix/bindings/stix_incident_0_3_1.py
@@ -4280,7 +4280,7 @@ Usage: python <Parser>.py [ -s ] <in_xml_file>
 """
 
 def usage():
-    print USAGE_TEXT
+    print(USAGE_TEXT)
     sys.exit(1)
 
 def get_root_tag(node):

--- a/stix/bindings/stix_indicator_1_1.py
+++ b/stix/bindings/stix_indicator_1_1.py
@@ -2915,7 +2915,7 @@ Usage: python <Parser>.py [ -s ] <in_xml_file>
 """
 
 def usage():
-    print USAGE_TEXT
+    print(USAGE_TEXT)
     sys.exit(1)
 
 def get_root_tag(node):

--- a/stix/bindings/stix_threat_actor_0_5_1.py
+++ b/stix/bindings/stix_threat_actor_0_5_1.py
@@ -1903,7 +1903,7 @@ Usage: python <Parser>.py [ -s ] <in_xml_file>
 """
 
 def usage():
-    print USAGE_TEXT
+    print(USAGE_TEXT)
     sys.exit(1)
 
 def get_root_tag(node):

--- a/stix/bindings/stix_ttp_0_6.py
+++ b/stix/bindings/stix_ttp_0_6.py
@@ -1995,7 +1995,7 @@ Usage: python <Parser>.py [ -s ] <in_xml_file>
 """
 
 def usage():
-    print USAGE_TEXT
+    print(USAGE_TEXT)
     sys.exit(1)
 
 def get_root_tag(node):


### PR DESCRIPTION
In order to be compatible with Python 3 and in accordance with the recommendations of [PEP 3105](http://www.python.org/dev/peps/pep-3105/), I have replaced the `print ' '` statement by the `print()`  function :

`$2to3 -f print -w -n .`
