### PR TITLE
Simplify GenericRelationshipLists

### DIFF
--- a/stix/common/generic_relationship.py
+++ b/stix/common/generic_relationship.py
@@ -1,3 +1,5 @@
+import collections
+
 import stix
 import stix.bindings.stix_common as common_binding
 
@@ -115,20 +117,84 @@ class GenericRelationship(stix.Entity):
 
 
 
-class GenericRelationshipList(stix.Entity):
+class GenericRelationshipList(collections.MutableSequence, stix.Entity):
     _namespace = "http://stix.mitre.org/common-1"
     _binding = common_binding
     _binding_class = _binding.GenericRelationshipListType
 
-    def __init__(self, scope):
+    def __init__(self, scope=None, *args):
+        super(GenericRelationshipList, self).__init__()
+        self._inner = []
         self.scope = scope
 
-    def to_obj(self, return_obj=None):
-        if not return_obj:
-            return_obj = self._binding_class()
+        for arg in args:
+            if isinstance(arg, list):
+                self.extend(arg)
+            else:
+                self.append(arg)
 
-        return_obj.scope = self.scope
-        return return_obj
+    def __getitem__(self, key):
+        return self._inner.__getitem__(key)
+
+    def __setitem__(self, key, value):
+        if not self._is_valid(value):
+            value = self._fix_value(value)
+        self._inner.__setitem__(key, value)
+
+    def __delitem__(self, key):
+        self._inner.__delitem__(key)
+
+    def __len__(self):
+        return len(self._inner)
+
+    def insert(self, idx, value):
+        if not self._is_valid(value):
+            value = self._fix_value(value)
+        self._inner.insert(idx, value)
+
+    def _is_valid(self, value):
+        """Check if this is a valid object to add to the list."""
+        # Subclasses can override this function, but if it becomes common, it's
+        # probably better to use self._contained_type.istypeof(value)
+        return isinstance(value, self._contained_type)
+
+    def _fix_value(self, value):
+        """Attempt to coerce value into the correct type.
+
+        Subclasses can override this function.
+        """
+        try:
+            new_value = self._contained_type(value)
+        except:
+            raise ValueError("Can't put '%s' (%s) into a %s" %
+                (value, type(value), self.__class__))
+        return new_value
+
+    # The next four functions can be overridden, but otherwise define the
+    # default behavior for EntityList subclasses which define the following
+    # class-level members:
+    # - _binding_class
+    # - _binding_var
+    # - _contained_type
+    # - _inner_name
+
+    def to_obj(self):
+        list_obj = self._binding_class()
+
+        setattr(list_obj, self._binding_var, [x.to_obj() for x in self])
+        if self.scope:
+            list_obj.set_scope(self.scope)
+
+        return list_obj
+
+    def to_dict(self):
+        d = {}
+
+        d[self._inner_name] = [h.to_dict() for h in self]
+        if self.scope:
+            d['scope'] = self.scope
+
+        return d
 
     @classmethod
     def from_obj(cls, obj, return_obj=None):
@@ -138,25 +204,24 @@ class GenericRelationshipList(stix.Entity):
         if not return_obj:
             return_obj = cls()
 
+        for item in getattr(obj, cls._binding_var):
+            return_obj.append(cls._contained_type.from_obj(item))
+
         return_obj.scope = obj.get_scope()
+
         return return_obj
-
-    def to_dict(self):
-        d = {}
-        if self.scope:
-            d['scope'] = self.scope
-
-        return d
 
     @classmethod
     def from_dict(cls, dict_repr, return_obj=None):
-        if not dict_repr:
+        if not isinstance(dict_repr, dict):
             return None
 
         if not return_obj:
             return_obj = cls()
 
+        for item in dict_repr.get(cls._inner_name, []):
+            return_obj.append(cls._contained_type.from_dict(item))
+
         return_obj.scope = dict_repr.get('scope')
+
         return return_obj
-
-

--- a/stix/common/related.py
+++ b/stix/common/related.py
@@ -13,7 +13,7 @@ class RelatedThreatActor(GenericRelationship):
     _binding = common_binding
     _binding_class = _binding.RelatedThreatActorType
 
-    def __init__(self, confidence=None, information_source=None, relationship=None, threat_actor=None ):
+    def __init__(self, threat_actor=None, confidence=None, information_source=None, relationship=None):
         super(RelatedThreatActor, self).__init__(confidence=confidence, information_source=information_source, relationship=relationship)
         self.threat_actor = threat_actor
 
@@ -76,7 +76,7 @@ class RelatedIndicator(GenericRelationship):
     _binding = common_binding
     _binding_class = _binding.RelatedIndicatorType
 
-    def __init__(self, confidence=None, information_source=None, relationship=None, indicator=None ):
+    def __init__(self, indicator=None, confidence=None, information_source=None, relationship=None):
         super(RelatedIndicator, self).__init__(confidence=confidence, information_source=information_source, relationship=relationship)
         self.indicator = indicator
 
@@ -139,7 +139,7 @@ class RelatedTTP(GenericRelationship):
     _binding = common_binding
     _binding_class = _binding.RelatedTTPType
 
-    def __init__(self, confidence=None, information_source=None, relationship=None, ttp=None ):
+    def __init__(self, ttp=None, confidence=None, information_source=None, relationship=None):
         super(RelatedTTP, self).__init__(confidence=confidence, information_source=information_source, relationship=relationship)
         self.ttp = ttp
 

--- a/stix/incident/attributed_threat_actors.py
+++ b/stix/incident/attributed_threat_actors.py
@@ -1,83 +1,20 @@
 # Copyright (c) 2014, The MITRE Corporation. All rights reserved.
 # See LICENSE.txt for complete terms.
 
-import stix
 import stix.bindings.incident as incident_binding
 from stix.common.generic_relationship import GenericRelationshipList
-from stix.threat_actor import ThreatActor
 from stix.common.related import RelatedThreatActor
+
 
 class AttributedThreatActors(GenericRelationshipList):
     _namespace = "http://stix.mitre.org/Incident-1"
     _binding = incident_binding
     _binding_class = incident_binding.AttributedThreatActorsType
+    _binding_var = "Threat_Actor"
+    _contained_type = RelatedThreatActor
+    _inner_name = "threat_actors"
 
     def __init__(self, threat_actors=None, scope=None):
-        super(AttributedThreatActors, self).__init__(scope=scope)
-        self.threat_actors = threat_actors
-
-    @property
-    def threat_actors(self):
-        return self._threat_actors
-
-    @threat_actors.setter
-    def threat_actors(self, value):
-        self._threat_actors = []
-
-        if isinstance(value, list):
-            for v in value:
-                self.add_threat_actor(v)
-        else:
-            self.add_threat_actor(value)
-
-    def add_threat_actor(self, threat_actor):
-        if not threat_actor:
-            return
-        elif isinstance(threat_actor, RelatedThreatActor):
-            self.threat_actors.append(threat_actor)
-        elif isinstance(threat_actor, ThreatActor):
-            self.threat_actors.append(RelatedThreatActor(threat_actor=threat_actor))
-        else:
-            raise ValueError('value must be instance of RelatedThreatActor')
-
-    def to_obj(self, return_obj=None):
-        if not return_obj:
-            return_obj = self._binding_class()
-
-        super(AttributedThreatActors, self).to_obj(return_obj)
-        return_obj.set_Threat_Actor([x.to_obj() for x in self.threat_actors])
-        return return_obj
-
-    @classmethod
-    def from_obj(cls, obj, return_obj=None):
-        if not obj:
-            return None
-
-        if not return_obj:
-            return_obj = cls()
-
-        super(AttributedThreatActors, cls).from_obj(obj, return_obj)
-
-        if obj.get_Threat_Actor():
-            return_obj.threat_actors = [RelatedThreatActor.from_obj(x) for x in obj.get_Threat_Actor()]
-
-        return return_obj
-
-    def to_dict(self):
-        d = super(AttributedThreatActors, self).to_dict()
-        if self.threat_actors:
-            d['threat_actors'] = [x.to_dict() for x in self.threat_actors]
-
-        return d
-
-    @classmethod
-    def from_dict(cls, dict_repr, return_obj=None):
-        if not dict_repr:
-            return None
-
-        if not return_obj:
-            return_obj = cls()
-
-        super(AttributedThreatActors, cls).from_dict(dict_repr, return_obj)
-        return_obj.threat_actors = [RelatedThreatActor.from_dict(x) for x in dict_repr.get('threat_actors', [])]
-        return return_obj
+        if threat_actors is None:
+            threat_actors = []
+        super(AttributedThreatActors, self).__init__(*threat_actors, scope=scope)

--- a/stix/incident/incident.py
+++ b/stix/incident/incident.py
@@ -100,7 +100,7 @@ class Incident(stix.Entity):
     @leveraged_ttps.setter
     def leveraged_ttps(self, value):
         if not value:
-            self._leveraged_ttps = None
+            self._leveraged_ttps = LeveragedTTPs()
         elif isinstance(value, LeveragedTTPs):
             self._leverage_ttps = value
         elif isinstance(value, TTP):
@@ -138,7 +138,7 @@ class Incident(stix.Entity):
     @attributed_threat_actors.setter
     def attributed_threat_actors(self, value):
         if not value:
-            self._attributed_threat_actors = None
+            self._attributed_threat_actors = AttributedThreatActors()
         elif isinstance(value, AttributedThreatActors):
             self._attributed_threat_actors = value
         elif isinstance(value, ThreatActor):
@@ -153,7 +153,7 @@ class Incident(stix.Entity):
     @related_indicators.setter
     def related_indicators(self, value):
         if not value:
-            self._related_indicators = None
+            self._related_indicators = RelatedIndicators()
         elif isinstance(value, RelatedIndicators):
             self._related_indicators = value
         elif isinstance(value, Indicator):

--- a/stix/incident/leveraged_ttps.py
+++ b/stix/incident/leveraged_ttps.py
@@ -1,85 +1,20 @@
 # Copyright (c) 2014, The MITRE Corporation. All rights reserved.
 # See LICENSE.txt for complete terms.
 
-import stix
 import stix.bindings.incident as incident_binding
 from stix.common.generic_relationship import GenericRelationshipList
 from stix.common.related import RelatedTTP
-from stix.ttp import TTP
+
 
 class LeveragedTTPs(GenericRelationshipList):
     _namespace = "http://stix.mitre.org/Incident-1"
     _binding = incident_binding
     _binding_class = incident_binding.LeveragedTTPsType
+    _binding_var = "Leveraged_TTP"
+    _contained_type = RelatedTTP
+    _inner_name = "ttps"
 
     def __init__(self, leveraged_ttps=None, scope=None):
-        super(LeveragedTTPs, self).__init__(scope=scope)
-        self.leveraged_ttps = None
-
-    @property
-    def leveraged_ttps(self):
-        return self._leveraged_ttps
-
-    @leveraged_ttps.setter
-    def leveraged_ttps(self, value):
-        self._leveraged_ttps = []
-
-        if isinstance(value, list):
-            for v in value:
-                self.add_leveraged_ttp(v)
-        else:
-            self.add_leveraged_ttp(value)
-
-    def add_leveraged_ttp(self, ttp):
-        if not ttp:
-            return
-        if isinstance(ttp, RelatedTTP):
-            self.leveraged_ttps.append(ttp)
-        elif isinstance(ttp, TTP):
-            self.leveraged_ttps.append(RelatedTTP(ttp=ttp))
-        else:
-            raise ValueError("Cannot add %s to leveraged_ttps list" % type(ttp))
-
-    def to_obj(self, return_obj=None):
-        if not return_obj:
-            return_obj = self._binding_class()
-
-        super(LeveragedTTPs, self).to_obj(return_obj)
-        return_obj.set_Leveraged_TTP([x.to_obj() for x in self.leveraged_ttps])
-        return return_obj
-
-    @classmethod
-    def from_obj(cls, obj, return_obj=None):
-        if not obj:
-            return None
-
-        if not return_obj:
-            return_obj = cls()
-
-        super(LeveragedTTPs, cls).from_obj(obj, return_obj)
-
-        if obj.get_Leveraged_TTP():
-            return_obj.leveraged_ttps = [RelatedTTP.from_obj(x) for x in obj.get_Leveraged_TTP()]
-
-        return return_obj
-
-    def to_dict(self):
-        d = super(LeveragedTTPs, self).to_dict()
-        if self.leveraged_ttps:
-            d['leveraged_ttps'] = [x.to_dict() for x in self.leveraged_ttps]
-
-        return d
-
-    @classmethod
-    def from_dict(cls, dict_repr, return_obj=None):
-        if not dict_repr:
-            return None
-
-        if not return_obj:
-            return_obj = cls()
-
-        super(LeveragedTTPs, cls).from_dict(dict_repr, return_obj)
-        return_obj.leveraged_ttps = [RelatedTTP.from_dict(x) for x in dict_repr.get('leveraged_ttps', [])]
-        return return_obj
-
-        
+        if leveraged_ttps is None:
+            leveraged_ttps = []
+        super(LeveragedTTPs, self).__init__(*leveraged_ttps, scope=scope)

--- a/stix/incident/related_indicators.py
+++ b/stix/incident/related_indicators.py
@@ -1,84 +1,20 @@
 # Copyright (c) 2014, The MITRE Corporation. All rights reserved.
 # See LICENSE.txt for complete terms.
 
-import stix
 import stix.bindings.incident as incident_binding
 from stix.common.generic_relationship import GenericRelationshipList
 from stix.common.related import RelatedIndicator
-from stix.indicator import Indicator
-from cybox.core import Observable, Object
+
 
 class RelatedIndicators(GenericRelationshipList):
     _namespace = "http://stix.mitre.org/Incident-1"
     _binding = incident_binding
     _binding_class = incident_binding.RelatedIndicatorsType
+    _binding_var = "Related_Indicator"
+    _contained_type = RelatedIndicator
+    _inner_name = "indicators"
 
     def __init__(self, indicators=None, scope=None):
-        super(RelatedIndicators, self).__init__(scope=scope)
-        self.indicators = indicators
-
-    @property
-    def indicators(self):
-        return self._indicators
-
-    @indicators.setter
-    def indicators(self, value):
-        self._indicators = []
-
-        if isinstance(value, list):
-            for v in value:
-                self.add_indicator(v)
-        else:
-            self.add_indicator(value)
-
-    def add_indicator(self, indicator):
-        if not indicator:
-            return
-        if isinstance(indicator, RelatedIndicator):
-            self.indicators.append(indicator)
-        elif isinstance(indicator, Indicator):
-            self.indicators.append(RelatedIndicator(indicator=indicator))
-        else:
-            raise ValueError("Cannot add %s to indicators list" % type(indicator))
-
-    def to_obj(self, return_obj=None):
-        if not return_obj:
-            return_obj = self._binding_class()
-
-        super(RelatedIndicators, self).to_obj(return_obj)
-        return_obj.set_Related_Indicator([x.to_obj() for x in self.indicators])
-        return return_obj
-
-    @classmethod
-    def from_obj(cls, obj, return_obj=None):
-        if not obj:
-            return None
-
-        if not return_obj:
-            return_obj = cls()
-
-        super(RelatedIndicators, cls).from_obj(obj, return_obj)
-
-        if obj.get_Related_Indicator():
-            return_obj.indicators = [RelatedIndicator.from_obj(x) for x in obj.get_Related_Indicator()]
-
-        return return_obj
-
-    def to_dict(self):
-        d = super(RelatedIndicators, self).to_dict()
-        if self.indicators:
-            d['indicators'] = [x.to_dict() for x in self.indicators]
-
-        return d
-
-    @classmethod
-    def from_dict(cls, dict_repr, return_obj=None):
-        if not dict_repr:
-            return None
-
-        if not return_obj:
-            return_obj = cls()
-
-        super(RelatedIndicators, cls).from_dict(dict_repr, return_obj)
-        return_obj.indicators = [RelatedIndicator.from_dict(x) for x in dict_repr.get('indicators', [])]
-        return return_obj
+        if indicators is None:
+            indicators = []
+        super(RelatedIndicators, self).__init__(*indicators, scope=scope)

--- a/stix/ttp/__init__.py
+++ b/stix/ttp/__init__.py
@@ -89,7 +89,7 @@ class TTP(stix.Entity):
         from .related_ttps import RelatedTTPs # avoid circular imports
         
         if not value:
-            self._related_ttps = None
+            self._related_ttps = RelatedTTPs()
         elif isinstance(value, RelatedTTPs):
             self._related_ttps = value
         else:

--- a/stix/ttp/related_ttps.py
+++ b/stix/ttp/related_ttps.py
@@ -1,82 +1,21 @@
 # Copyright (c) 2014, The MITRE Corporation. All rights reserved.
 # See LICENSE.txt for complete terms.
 
-import stix
 import stix.bindings.ttp as ttp_binding
 from stix.common.generic_relationship import GenericRelationshipList
 from stix.common.related import RelatedTTP
-from stix.ttp import TTP
+
 
 class RelatedTTPs(GenericRelationshipList):
     _namespace = "http://stix.mitre.org/TTP-1"
     _binding = ttp_binding
     _binding_class = _binding.RelatedTTPsType
+    _binding_var = "Related_TTP"
+    _contained_type = RelatedTTP
+    _inner_name = "ttps"
 
     def __init__(self, related_ttps=None, scope=None):
-        super(RelatedTTPs, self).__init__(scope=scope)
-        self.related_ttps = None
+        if related_ttps is None:
+            related_ttps = []
+        super(RelatedTTPs, self).__init__(*related_ttps, scope=scope)
 
-    @property
-    def related_ttps(self):
-        return self._related_ttps
-
-    @related_ttps.setter
-    def related_ttps(self, value):
-        self._related_ttps = []
-
-        if isinstance(value, list):
-            for v in value:
-                self.add_related_ttp(v)
-        else:
-            self.add_related_ttp(value)
-
-    def add_related_ttp(self, ttp):
-        if not ttp:
-            return
-        if isinstance(ttp, RelatedTTP):
-            self.related_ttps.append(ttp)
-        elif isinstance(ttp, TTP):
-            self.related_ttps.append(RelatedTTP(ttp=ttp))
-        else:
-            raise ValueError("Cannot add %s to related_ttps list" % type(ttp))
-
-    def to_obj(self, return_obj=None):
-        if not return_obj:
-            return_obj = self._binding_class()
-
-        super(RelatedTTPs, self).to_obj(return_obj)
-        return_obj.set_Related_TTP([x.to_obj() for x in self.related_ttps])
-        return return_obj
-
-    @classmethod
-    def from_obj(cls, obj, return_obj=None):
-        if not obj:
-            return None
-
-        if not return_obj:
-            return_obj = cls()
-
-        super(RelatedTTPs, cls).from_obj(obj, return_obj)
-
-        if obj.get_Related_TTP():
-            return_obj.related_ttps = [RelatedTTP.from_obj(x) for x in obj.get_Related_TTP()]
-
-        return return_obj
-
-    def to_dict(self):
-        d = super(RelatedTTPs, self).to_dict()
-        if self.related_ttps:
-            d['related_ttps'] = [x.to_dict() for x in self.related_ttps]
-
-        return d
-
-    @classmethod
-    def from_dict(cls, dict_repr, return_obj=None):
-        if not dict_repr:
-            return None
-        if not return_obj:
-            return_obj = cls()
-
-        super(RelatedTTPs, cls).from_dict(dict_repr, return_obj)
-        return_obj.related_ttps = [RelatedTTP.from_dict(x) for x in dict_repr.get('related_ttps', [])]
-        return return_obj


### PR DESCRIPTION
I tried to simplify this code a bit so we didn't keep duplicating the same file over again, only changing variable names. All of the unit tests still pass, and here's an example of using the new classes. Note that the `add_*_*` functions are gone and can be replaced with a simple `append`.

``` python
from stix.common.related import RelatedThreatActor
from stix.incident import Incident
from stix.threat_actor import ThreatActor
i = Incident()
ta = ThreatActor()
ta.title = "Bob"
i.attributed_threat_actors.append(ta)
rta = RelatedThreatActor()
rta.confidence="High"
rta.threat_actor = ThreatActor()
rta.threat_actor.title = "Jim"
i.attributed_threat_actors.append(rta)

print i.to_xml()
```
