### PR TITLE
Add support for related exploit targets in Exploit Target API.

### DIFF
--- a/stix/common/__init__.py
+++ b/stix/common/__init__.py
@@ -14,13 +14,14 @@ from .statement import Statement
 from .tools import ToolInformation
 
 from .related import (GenericRelationshipList, RelatedCampaign, RelatedCOA,
-        RelatedIdentity, RelatedIncident, RelatedIndicator, RelatedObservable,
-        RelatedThreatActor, RelatedTTP)
+        RelatedExploitTarget, RelatedIdentity, RelatedIncident, 
+        RelatedIndicator, RelatedObservable, RelatedThreatActor, RelatedTTP)
 
 # Patch in base types of Related* types
 from cybox.core import Observable
 from stix.campaign import Campaign
 from stix.coa import CourseOfAction
+from stix.exploit_target import ExploitTarget
 from stix.incident import Incident
 from stix.indicator import Indicator
 from stix.threat_actor import ThreatActor
@@ -28,6 +29,7 @@ from stix.ttp import TTP
 
 RelatedCampaign._base_type = Campaign
 RelatedCOA._base_type = CourseOfAction
+RelatedExploitTarget._base_type = ExploitTarget
 RelatedIdentity._base_type = Identity
 RelatedIncident._base_type = Incident
 RelatedIndicator._base_type = Indicator

--- a/stix/common/related.py
+++ b/stix/common/related.py
@@ -334,6 +334,13 @@ class RelatedCOA(_BaseRelated):
     # _base_type is set in common/__init__.py
     _inner_var = "Course_Of_Action"
 
+class RelatedExploitTarget(_BaseRelated):
+    _namespace = "http://stix.mitre.org/common-1"
+    _binding = common_binding
+    _binding_class = common_binding.RelatedExploitTargetType
+    # _base_type is set in common/__init__.py
+    _inner_var = "Exploit_Target"
+
 class RelatedIdentity(_BaseRelated):
     _namespace = 'http://stix.mitre.org/common-1'
     _binding = common_binding

--- a/stix/exploit_target/__init__.py
+++ b/stix/exploit_target/__init__.py
@@ -6,11 +6,13 @@ import stix.utils
 from stix.utils import dates
 
 import stix.bindings.exploit_target as exploit_target_binding
-from stix.common.related import (GenericRelationshipList, RelatedCOA)
+from stix.common.related import (GenericRelationshipList, RelatedCOA, RelatedExploitTarget)
 from stix.common import StructuredText, VocabString, InformationSource, Statement
 from stix.coa import CourseOfAction
 from stix.data_marking import Marking
 from .vulnerability import Vulnerability
+from .weakness import Weakness
+from .configuration import Configuration
 
 class ExploitTarget(stix.Entity):
     _binding = exploit_target_binding
@@ -29,7 +31,10 @@ class ExploitTarget(stix.Entity):
         self.information_source = None
         self.handling = None
         self.potential_coas = PotentialCOAs()
+        self.related_exploit_targets = RelatedExploitTargets()
         self.vulnerabilities = None
+        self.weakness = None
+        self.configuration = None
 
     @property
     def timestamp(self):
@@ -122,6 +127,52 @@ class ExploitTarget(stix.Entity):
         else:
             raise ValueError('Cannot add type %s to vulnerabilities list' % type(v))
  
+    @property
+    def weakness(self):
+        return self._weakness
+    
+    @weakness.setter
+    def weakness(self, value):
+        self._weakness = []
+        if not value:
+            return
+        elif isinstance(value, list):
+            for v in value:
+                self.add_weakness(v)
+        else:
+            self.add_weakness(value)
+            
+    def add_weakness(self, v):
+        if not v:
+            return
+        elif isinstance(v, Weakness):
+            self.weakness.append(v)
+        else:
+            raise ValueError('Cannot add type %s to weakness list' % type(v))
+ 
+    @property
+    def configuration(self):
+        return self._configuration
+    
+    @configuration.setter
+    def configuration(self, value):
+        self._configuration = []
+        if not value:
+            return
+        elif isinstance(value, list):
+            for v in value:
+                self.add_configuration(v)
+        else:
+            self.add_configuration(value)
+            
+    def add_configuration(self, v):
+        if not v:
+            return
+        elif isinstance(v, Configuration):
+            self.configuration.append(v)
+        else:
+            raise ValueError('Cannot add type %s to configuration list' % type(v))
+ 
     def to_obj(self, return_obj=None):
         if not return_obj:
             return_obj = self._binding_class()
@@ -142,8 +193,14 @@ class ExploitTarget(stix.Entity):
             return_obj.set_Handling(self.handling.to_obj())
         if self.potential_coas:
             return_obj.set_Potential_COAs(self.potential_coas.to_obj())
+        if self.related_exploit_targets:
+            return_obj.set_Related_Exploit_Targets(self.related_exploit_targets.to_obj())
         if self.vulnerabilities:
             return_obj.set_Vulnerability([x.to_obj() for x in self.vulnerabilities])
+        if self.weakness:
+            return_obj.set_Weakness([x.to_obj() for x in self.weakness])
+        if self.configuration:
+            return_obj.set_Configuration([x.to_obj() for x in self.configuration])
             
         return return_obj
 
@@ -166,7 +223,10 @@ class ExploitTarget(stix.Entity):
             return_obj.information_source = InformationSource.from_obj(obj.get_Information_Source())
             return_obj.handling = Marking.from_obj(obj.get_Handling())
             return_obj.potential_coas = PotentialCOAs.from_obj(obj.get_Potential_COAs())
+            return_obj.related_exploit_targets = RelatedExploitTargets.from_obj(obj.get_Related_Exploit_Targets())
             return_obj.vulnerabilities = [Vulnerability.from_obj(x) for x in obj.get_Vulnerability()]
+            return_obj.weakness = [Weakness.from_obj(x) for x in obj.get_Weakness()]
+            return_obj.configuration = [Configuration.from_obj(x) for x in obj.get_Configuration()]
 
         return return_obj
 
@@ -192,8 +252,14 @@ class ExploitTarget(stix.Entity):
             d['handling'] = self.handling.to_dict()
         if self.potential_coas:
             d['potential_coas'] = self.potential_coas.to_dict()
+        if self.related_exploit_targets:
+            d['related_exploit_targets'] = self.related_exploit_targets.to_dict()
         if self.vulnerabilities:
             d['vulnerabilities'] = [x.to_dict() for x in self.vulnerabilities]
+        if self.weakness:
+            d['weakness'] = [x.to_dict() for x in self.weakness]
+        if self.configuration:
+            d['configuration'] = [x.to_dict() for x in self.configuration]
 
         return d
 
@@ -214,7 +280,10 @@ class ExploitTarget(stix.Entity):
         return_obj.information_source = InformationSource.from_dict(dict_repr.get('information_source'))
         return_obj.handling = Marking.from_dict(dict_repr.get('handling'))
         return_obj.potential_coas = PotentialCOAs.from_dict(dict_repr.get('potential_coas'))
+        return_obj.related_exploit_targets = RelatedExploitTargets.from_dict(dict_repr.get('related_exploit_targets'))
         return_obj.vulnerabilities = [Vulnerability.from_dict(x) for x in dict_repr.get('vulnerabilities', [])]
+        return_obj.weakness = [Weakness.from_dict(x) for x in dict_repr.get('weakness', [])]
+        return_obj.configuration = [Configuration.from_dict(x) for x in dict_repr.get('configuration', [])]
         
         return return_obj
 
@@ -230,3 +299,16 @@ class PotentialCOAs(GenericRelationshipList):
         if coas is None:
             coas = []
         super(PotentialCOAs, self).__init__(*coas, scope=scope)
+
+class RelatedExploitTargets(GenericRelationshipList):
+    _namespace = "http://stix.mitre.org/ExploitTarget-1"
+    _binding = exploit_target_binding
+    _binding_class = exploit_target_binding.RelatedExploitTargetsType
+    _binding_var = "Related_Exploit_Target"
+    _contained_type = RelatedExploitTarget
+    _inner_name = "related_exploit_targets"
+
+    def __init__(self, related_exploit_targets=None, scope=None):
+        if related_exploit_targets is None:
+            related_exploit_targets = []
+        super(RelatedExploitTargets, self).__init__(*related_exploit_targets, scope=scope)

--- a/stix/exploit_target/configuration.py
+++ b/stix/exploit_target/configuration.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2014, The MITRE Corporation. All rights reserved.
+# See LICENSE.txt for complete terms.
+
+import stix
+import stix.bindings.exploit_target as exploit_target_binding
+from stix.common import StructuredText
+
+class Configuration(stix.Entity):
+    _binding = exploit_target_binding
+    _binding_class = _binding.ConfigurationType
+    _namespace = "http://stix.mitre.org/ExploitTarget-1"
+    
+    def __init__(self, description=None, short_description=None, cce_id=None):
+        self.description = description
+        self.short_description = short_description
+        self.cce_id = cce_id
+
+    @property
+    def cce_id(self):
+        return self._cce_id
+
+    @cce_id.setter
+    def cce_id(self, value):
+        self._cce_id = value
+
+    @property
+    def description(self):
+        return self._description
+
+    @description.setter
+    def description(self, value):
+        if value:
+            if isinstance(value, StructuredText):
+                self._description = value
+            else:
+                self._description = StructuredText(value=value)
+        else:
+            self._description = None
+
+    @property
+    def short_description(self):
+        return self._short_description
+
+    @short_description.setter
+    def short_description(self, value):
+        if value:
+            if isinstance(value, StructuredText):
+                self._short_description = value
+            else:
+                self._short_description = StructuredText(value=value)
+        else:
+            self._short_description = None
+
+    def to_obj(self, return_obj=None):
+        if not return_obj:
+            return_obj = self._binding_class()
+
+        return_obj.set_Title(self.title)
+        return_obj.set_CCE_ID(self.cve_id)
+
+        if self.description:
+            return_obj.set_Description(self.description.to_obj())
+        if self.short_description:
+            return_obj.set_Short_Description(self.short_description.to_obj())
+        return return_obj
+
+    @classmethod
+    def from_obj(cls, obj, return_obj=None):
+        if not obj:
+            return None
+        if not return_obj:
+            return_obj = cls()
+
+        return_obj.title = obj.get_Title()
+        return_obj.cce_id = obj.get_CCE_ID()
+        return_obj.description = StructuredText.from_obj(obj.get_Description())
+        return_obj.short_description = StructuredText.from_obj(obj.get_Short_Description())
+        return return_obj
+
+    def to_dict(self):
+        d = {}
+        if self.title:
+            d['title'] = self.title
+        if self.description:
+            d['description'] = self.description.to_dict()
+        if self.short_description:
+            d['short_description'] = self.short_description.to_dict()
+        if self.cce_id:
+            d['cce_id'] = self.cce_id
+
+        return d
+
+    @classmethod
+    def from_dict(cls, dict_repr, return_obj=None):
+        if not dict_repr:
+            return None
+        if not return_obj:
+            return_obj = cls()
+
+        return_obj.title = dict_repr.get('title')
+        return_obj.description = StructuredText.from_dict(dict_repr.get('description'))
+        return_obj.short_description = StructuredText.from_dict(dict_repr.get('short_description'))
+        return_obj.cce_id = dict_repr.get('cce_id')
+        return return_obj

--- a/stix/exploit_target/weakness.py
+++ b/stix/exploit_target/weakness.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2014, The MITRE Corporation. All rights reserved.
+# See LICENSE.txt for complete terms.
+
+import stix
+import stix.bindings.exploit_target as exploit_target_binding
+from stix.common import StructuredText
+
+class Weakness(stix.Entity):
+    _binding = exploit_target_binding
+    _binding_class = _binding.WeaknessType
+    _namespace = "http://stix.mitre.org/ExploitTarget-1"
+    
+    def __init__(self, description=None, short_description=None, cwe_id=None):
+        self.cwe_id = cwe_id
+        self.description = description
+        self.short_description = short_description
+
+    @property
+    def cwe_id(self):
+        return self._cwe_id
+
+    @cwe_id.setter
+    def cwe_id(self, value):
+        self._cwe_id = value
+
+    @property
+    def description(self):
+        return self._description
+
+    @description.setter
+    def description(self, value):
+        if value:
+            if isinstance(value, StructuredText):
+                self._description = value
+            else:
+                self._description = StructuredText(value=value)
+        else:
+            self._description = None
+
+    @property
+    def short_description(self):
+        return self._short_description
+
+    @short_description.setter
+    def short_description(self, value):
+        if value:
+            if isinstance(value, StructuredText):
+                self._short_description = value
+            else:
+                self._short_description = StructuredText(value=value)
+        else:
+            self._short_description = None
+
+    def to_obj(self, return_obj=None):
+        if not return_obj:
+            return_obj = self._binding_class()
+
+        return_obj.set_Title(self.title)
+        return_obj.set_CWE_ID(self.cve_id)
+
+        if self.description:
+            return_obj.set_Description(self.description.to_obj())
+        if self.short_description:
+            return_obj.set_Short_Description(self.short_description.to_obj())
+        return return_obj
+
+    @classmethod
+    def from_obj(cls, obj, return_obj=None):
+        if not obj:
+            return None
+        if not return_obj:
+            return_obj = cls()
+
+        return_obj.title = obj.get_Title()
+        return_obj.cwe_id = obj.get_CWE_ID()
+        return_obj.description = StructuredText.from_obj(obj.get_Description())
+        return_obj.short_description = StructuredText.from_obj(obj.get_Short_Description())
+        return return_obj
+
+    def to_dict(self):
+        d = {}
+        if self.title:
+            d['title'] = self.title
+        if self.description:
+            d['description'] = self.description.to_dict()
+        if self.short_description:
+            d['short_description'] = self.short_description.to_dict()
+        if self.cwe_id:
+            d['cwe_id'] = self.cwe_id
+
+        return d
+
+    @classmethod
+    def from_dict(cls, dict_repr, return_obj=None):
+        if not dict_repr:
+            return None
+        if not return_obj:
+            return_obj = cls()
+
+        return_obj.title = dict_repr.get('title')
+        return_obj.description = StructuredText.from_dict(dict_repr.get('description'))
+        return_obj.short_description = StructuredText.from_dict(dict_repr.get('short_description'))
+        return_obj.cwe_id = dict_repr.get('cwe_id')
+        return return_obj

--- a/stix/test/exploit_target_test.py
+++ b/stix/test/exploit_target_test.py
@@ -17,14 +17,41 @@ class ExploitTargetTests(EntityTestCase, unittest.TestCase):
             },
         },
         'handling': [
-            {
-                'marking_structure': [{
-                    'marking_model_name': 'TLP',
-                    'color': "RED",
-                    'xsi:type': "tlpMarking:TLPMarkingStructureType",
-                }]
-            }
+        {
+            'marking_structure': [{
+                'marking_model_name': 'TLP',
+                'color': "RED",
+                'xsi:type': "tlpMarking:TLPMarkingStructureType",
+            }]
+        }
         ],
+        'related_exploit_targets': {
+            'scope': 'inclusive',
+            'related_exploit_targets': [{
+                'exploit_target': {
+                    'id': 'example:ExploitTarget-1',
+                    'version': '1.1',
+                    'title': "ExploitTarget1",
+                    'description': "This is a long description about an ExploitTarget",
+                    'short_description': "an ExploitTarget",
+                    'information_source': {
+                        'description': "Mr. Evil's enemy",
+                        'identity': {
+                            'name': "Ms. Good",
+                        },
+                    },
+                    'handling': [
+                    {
+                        'marking_structure': [{
+                            'marking_model_name': 'TLP',
+                            'color': "RED",
+                            'xsi:type': "tlpMarking:TLPMarkingStructureType",
+                        }]
+                    }
+                    ]
+                }       
+            }]
+        },
         'potential_coas': {
             'scope': 'inclusive',
             'coas': [


### PR DESCRIPTION
Expansion on #45 to add related exploit target structure. Also adds `weakness` and `configuration` support to ExploitTarget API.
