### PR TITLE
Implement Related Packages and Related COAs for Course of Action API

### DIFF
--- a/stix/coa/__init__.py
+++ b/stix/coa/__init__.py
@@ -7,7 +7,7 @@ import dateutil
 import stix
 import stix.utils
 import stix.bindings.course_of_action as coa_binding
-from stix.common.related import (GenericRelationshipList, RelatedPackageRefs)
+from stix.common.related import (GenericRelationshipList, RelatedCOA, RelatedPackageRefs)
 from stix.common import StructuredText, VocabString, InformationSource, Statement
 from stix.data_marking import Marking
 from .objective import Objective
@@ -45,7 +45,7 @@ class CourseOfAction(stix.Entity):
         self.related_packages = RelatedPackageRefs()
         # self.parameter_observables = None
         # self.structured_coa = None
-        # self.related_coas = None
+        self.related_coas = RelatedCOAs()
 
     @property
     def timestamp(self):
@@ -231,6 +231,8 @@ class CourseOfAction(stix.Entity):
             return_obj.set_Objective(self.objective.to_obj())
         if self.related_packages:
             return_obj.set_Related_Packages(self.related_packages.to_obj())
+        if self.related_coas:
+            return_obj.set_Related_COAs(self.related_coas.to_obj())
         
         return return_obj
 
@@ -259,6 +261,7 @@ class CourseOfAction(stix.Entity):
             return_obj.handling = Marking.from_obj(obj.get_Handling())
             return_obj.objective = Objective.from_obj(obj.get_Objective())
             return_obj.related_packages = RelatedPackageRefs.from_obj(obj.get_Related_Packages())
+            return_obj.related_coas = RelatedCOAs.from_obj(obj.get_Related_COAs())
             
         return return_obj
 
@@ -296,6 +299,8 @@ class CourseOfAction(stix.Entity):
             d['objective'] = self.objective.to_dict()
         if self.related_packages:
             d['related_packages'] = self.related_packages.to_dict()
+        if self.related_coas:
+            d['related_coas'] = self.related_coas.to_dict()
         
         return d
 
@@ -322,6 +327,20 @@ class CourseOfAction(stix.Entity):
         return_obj.handling = Marking.from_dict(dict_repr.get('handling'))
         return_obj.objective = Objective.from_dict(dict_repr.get('objective'))
         return_obj.related_packages = RelatedPackageRefs.from_dict(dict_repr.get('related_packages'))
+        return_obj.related_coas = RelatedCOAs.from_dict(dict_repr.get('related_coas'))
         
         return return_obj
 
+
+class RelatedCOAs(GenericRelationshipList):
+    _namespace = "http://stix.mitre.org/ExploitTarget-1"
+    _binding = coa_binding
+    _binding_class = coa_binding.RelatedCOAsType
+    _binding_var = "Related_COA"
+    _contained_type = RelatedCOA
+    _inner_name = "coas"
+
+    def __init__(self, coas=None, scope=None):
+        if coas is None:
+            coas = []
+        super(RelatedCOAs, self).__init__(*coas, scope=scope)

--- a/stix/test/coa_test.py
+++ b/stix/test/coa_test.py
@@ -43,6 +43,47 @@ class COATests(EntityTestCase, unittest.TestCase):
                 {'idref': "example:Package-AB", 'relationship': "Parent"},
                 {'idref': "example:Package-CD", 'relationship': "Child"}
             ]
+        },
+        'related_coas': {
+            'scope': 'inclusive',
+            'coas': [
+                { 'course_of_action': {
+                    'id': 'example:coa-5',
+                    'idref': 'example:coa-6',
+                    'version': '1.1',
+                    'timestamp': "2014-03-25T09:35:12",
+                    'title': "COA Related",
+                    'description': "This is a long description about a course of action that is related",
+                    'short_description': "a COA",
+                    'stage': "Remedy",
+                    'type': "Redirection",
+                    'cost': {
+                        'value': "50"
+                    },
+                    'efficacy': {
+                        'value': "Half"
+                    },
+                    'impact': {
+                        'value': "Large"
+                    },
+                    'information_source': {
+                        'description': "Mr. Evil's enemy",
+                        'identity': {
+                            'name': "Ms. Good",
+                        },
+                    },
+                    'handling': [
+                    {
+                        'marking_structure': [{
+                            'marking_model_name': 'TLP',
+                            'color': "GREEN",
+                            'xsi:type': "tlpMarking:TLPMarkingStructureType",
+                        }]
+                    }
+                    ]
+                }
+            }
+            ]
         }
     }
 


### PR DESCRIPTION
Addition to #44.

@bworrell, this leaves only the `structured_coa` attribute to implement for Course of Action. I wasn't really sure how to tackle that one, so I left it out.
