### PR TITLE
Add exploit targets to TTPs

### DIFF
--- a/stix/test/ttp_test.py
+++ b/stix/test/ttp_test.py
@@ -15,6 +15,33 @@ class TTPTests(EntityTestCase, unittest.TestCase):
                 {'title': "Tool"}
             ],
             'infrastructure': {'title': "Infrastructure"},
+        },
+        'exploit_targets': {
+            'scope': "exclusive",
+            'exploit_targets': [
+                {
+                    'exploit_target': {'id': 'example:ExploitTarget-1',
+                    'version': '1.1',
+                    'title': "ExploitTarget1",
+                    'description': "This is a long description about an ExploitTarget",
+                    'short_description': "an ExploitTarget",
+                    'information_source': {
+                        'description': "Mr. Evil's enemy",
+                        'identity': {
+                            'name': "Ms. Good",
+                        },
+                    },
+                    'handling': [
+                    {
+                        'marking_structure': [{
+                            'marking_model_name': 'TLP',
+                            'color': "RED",
+                            'xsi:type': "tlpMarking:TLPMarkingStructureType",
+                        }]
+                    }
+                    ]}
+                },
+            ]
         }
     }
 

--- a/stix/ttp/__init__.py
+++ b/stix/ttp/__init__.py
@@ -31,8 +31,7 @@ class TTP(stix.Entity):
         self.intended_effects = None
         self.resources = None
         self.victim_targeting = VictimTargeting()
-
-        self.exploit_targets = None # TODO: stix.ExploitTarget not implemented yet
+        self.exploit_targets = None
 
     @property
     def id_(self):
@@ -130,6 +129,19 @@ class TTP(stix.Entity):
             raise ValueError("value must be RelatedTTPs instance")
 
     @property
+    def exploit_targets(self):
+        return self._exploit_targets
+
+    @exploit_targets.setter
+    def exploit_targets(self, value):
+        if not value:
+            self._exploit_targets = ExploitTargets()
+        elif isinstance(value, ExploitTargets):
+            self._exploit_targets = value
+        else:
+            raise ValueError("value must be ExploitTargets instance")
+
+    @property
     def information_source(self):
         return self._information_source
 
@@ -210,6 +222,8 @@ class TTP(stix.Entity):
             return_obj.set_Behavior(self.behavior.to_obj())
         if self.related_ttps:
             return_obj.set_Related_TTPs(self.related_ttps.to_obj())
+        if self.exploit_targets:
+            return_obj.set_Exploit_Targets(self.exploit_targets.to_obj())
         if self.information_source:
             return_obj.set_Information_Source(self.information_source.to_obj())
         if self.intended_effects:
@@ -239,6 +253,7 @@ class TTP(stix.Entity):
             return_obj.short_description = StructuredText.from_obj(obj.get_Short_Description())
             return_obj.behavior = Behavior.from_obj(obj.get_Behavior())
             return_obj.related_ttps = RelatedTTPs.from_obj(obj.get_Related_TTPs())
+            return_obj.exploit_targets = ExploitTargets.from_obj(obj.get_Exploit_Targets())
             return_obj.information_source = InformationSource.from_obj(obj.get_Information_Source())
             return_obj.resources = Resource.from_obj(obj.get_Resources())
             return_obj.victim_targeting = VictimTargeting.from_obj(obj.get_Victim_Targeting())
@@ -268,6 +283,8 @@ class TTP(stix.Entity):
             d['behavior'] = self.behavior.to_dict()
         if self.related_ttps:
             d['related_ttps'] = self.related_ttps.to_dict()
+        if self.exploit_targets:
+            d['exploit_targets'] = self.exploit_targets.to_dict()
         if self.information_source:
             d['information_source'] = self.information_source.to_dict()
         if self.intended_effects:
@@ -295,6 +312,7 @@ class TTP(stix.Entity):
         return_obj.short_description = StructuredText.from_dict(dict_repr.get('short_description'))
         return_obj.behavior = Behavior.from_dict(dict_repr.get('behavior'))
         return_obj.related_ttps = RelatedTTPs.from_dict(dict_repr.get('related_ttps'))
+        return_obj.exploit_targets = ExploitTargets.from_dict(dict_repr.get('exploit_targets'))
         return_obj.information_source = InformationSource.from_dict(dict_repr.get('information_source'))
         return_obj.intended_effects = [Statement.from_dict(x) for x in dict_repr.get('intended_effects', [])]
         return_obj.resources = Resource.from_dict(dict_repr.get('resources'))
@@ -304,3 +322,4 @@ class TTP(stix.Entity):
 
 # Avoid circular imports
 from .related_ttps import RelatedTTPs
+from .exploit_targets import ExploitTargets

--- a/stix/ttp/exploit_targets.py
+++ b/stix/ttp/exploit_targets.py
@@ -1,0 +1,14 @@
+# Copyright (c) 2014, The MITRE Corporation. All rights reserved.
+# See LICENSE.txt for complete terms.
+
+import stix.bindings.ttp as ttp_binding
+from stix.common.related import GenericRelationshipList, RelatedExploitTarget
+
+
+class ExploitTargets(GenericRelationshipList):
+    _namespace = "http://stix.mitre.org/TTP-1"
+    _binding = ttp_binding
+    _binding_class = _binding.ExploitTargetsType
+    _binding_var = "Exploit_Target"
+    _contained_type = RelatedExploitTarget
+    _inner_name = "exploit_targets"


### PR DESCRIPTION
To finish #48.

The exploit target structure for TTPs is a little convoluted - the TTP binding class has an Exploit Targets type of its own, which points to the stix_common bindings for `RelatedExploitTargetType`, which actually has an exploit target as one of its attributes. 

@bworrell, please make sure I implemented this correctly, as it took me a bit to wrap my head around that structure.
