### PR TITLE
updated __all__ in stix.bindings.stix_common

### DIFF
--- a/stix/bindings/stix_common.py
+++ b/stix/bindings/stix_common.py
@@ -4365,7 +4365,7 @@ if __name__ == '__main__':
 __all__ = [
     "GenericRelationshipType",
     "DateTimeWithPrecisionType",
-    "ProfileType",
+    "ProfilesType",
     "RelatedPackageRefType",
     "RelatedPackageRefsType",
     "ToolInformationType",


### PR DESCRIPTION
Doing "from stix.bindings.stix_common import *" fails due to
nonexistent ContributorsType. Fixed this problem by updating the **all**
list with the current set of Types
