### PR TITLE
Remove auto-ids on non-core constructs

### DIFF
--- a/stix/common/identity.py
+++ b/stix/common/identity.py
@@ -16,7 +16,7 @@ class Identity(stix.Entity):
     _namespace = 'http://stix.mitre.org/common-1'
 
     def __init__(self, id_=None, idref=None, name=None, related_identities=None):
-        self.id_ = id_ or stix.utils.create_id("Identity")
+        self.id_ = id_
         self.idref = idref
         self.name = name
         self.related_identities = RelatedIdentities()

--- a/stix/common/kill_chains.py
+++ b/stix/common/kill_chains.py
@@ -11,7 +11,7 @@ class KillChain(stix.Entity):
     _binding_class = _binding.KillChainType
     
     def __init__(self, id_=None, name=None):
-        self.id_ = id_ or stix.utils.create_id("killchain")
+        self.id_ = id_
         self.name = name
         self.definer = None
         self.reference = None
@@ -106,7 +106,7 @@ class KillChainPhase(stix.Entity):
     _binding_class = _binding.KillChainPhaseType
     
     def __init__(self, phase_id=None, name=None, ordinality=None):
-        self.phase_id = phase_id or stix.utils.create_id("killchainphase")
+        self.phase_id = phase_id
         self.name = name
         self.ordinality = ordinality
     

--- a/stix/indicator/test_mechanism.py
+++ b/stix/indicator/test_mechanism.py
@@ -12,7 +12,7 @@ class _BaseTestMechanism(stix.Entity):
     _binding_class = indicator_binding.TestMechanismType()
     
     def __init__(self, id_=None, idref=None):
-        self.id_ = id_ or stix.utils.create_id("testmechanism")
+        self.id_ = id_
         self.idref = idref
         self.efficacy = None
         self.producer = None

--- a/stix/ttp/attack_pattern.py
+++ b/stix/ttp/attack_pattern.py
@@ -12,7 +12,7 @@ class AttackPattern(stix.Entity):
     _namespace = "http://stix.mitre.org/TTP-1"
 
     def __init__(self, id_=None, title=None, description=None, short_description=None):
-        self.id_ = id_ or stix.utils.create_id("attackpattern")
+        self.id_ = id_
         self.capec_id = None
         self.title = title
         self.description = description

--- a/stix/ttp/exploit.py
+++ b/stix/ttp/exploit.py
@@ -12,7 +12,7 @@ class Exploit(stix.Entity):
     _namespace = "http://stix.mitre.org/TTP-1"
 
     def __init__(self, id_=None, title=None, description=None, short_description=None):
-        self.id_ = id_ or stix.utils.create_id("exploit")
+        self.id_ = id_
         self.title = title
         self.description = description
         self.short_description = short_description

--- a/stix/ttp/infrastructure.py
+++ b/stix/ttp/infrastructure.py
@@ -14,7 +14,7 @@ class Infrastructure(stix.Entity):
     _namespace = "http://stix.mitre.org/TTP-1"
 
     def __init__(self, id_=None, title=None, description=None, short_description=None):
-        self.id_ = id_ or stix.utils.create_id("infrastructure")
+        self.id_ = id_
         self.title = title
         self.description = description
         self.short_description = short_description

--- a/stix/ttp/malware_instance.py
+++ b/stix/ttp/malware_instance.py
@@ -13,7 +13,7 @@ class MalwareInstance(stix.Entity):
     _namespace = "http://stix.mitre.org/TTP-1"
 
     def __init__(self, id_=None, title=None, description=None, short_description=None):
-        self.id_ = id_ or stix.utils.create_id("malware")
+        self.id_ = id_
         self.title = title
         self.description = description
         self.short_description = short_description


### PR DESCRIPTION
Fixes #174 

Removed auto-generated IDs on:
- Identity
- Kill Chain
- Kill Chain Phase
- Test Mechanism
- Attack Pattern
- Exploit
- Infrastructure
- Malware Instance

This leaves only the items listed in [Assigning IDs](http://stixproject.github.io/documentation/suggested-practices/) as those that are auto-assigned IDs (assuming CybOX is kind enough to provide IDs for its objects.)
