### PR TITLE
Fixing problem of randomly generated root observable id in indicators

### DIFF
--- a/stix/indicator/indicator.py
+++ b/stix/indicator/indicator.py
@@ -1032,7 +1032,38 @@ class Indicator(stix.Entity):
         for observable_ in observables:
             observable_composition.add(observable_)
 
+            
+        # Below, a root observable is created that contains the observable
+        # composition. Unfortunately, there is no way to explicitly set
+        # the identifier of that root observable. So we derive the
+        # id from the id of the embedding Indicator
+            
+        try:
+            root_observable_ns, root_observable_id_candidate = self._id.split(':',1)
+        except:
+            root_observable_ns = None
+            root_observable_id_candidate = self._id
+
+        # It is likely (though not completely sure), that the identifier is something
+        # like "Identifier-<uuid4>" or "Identifier-<uuid4>". If that is the
+        # case, we create the identifier for the root-observable by 
+        # replacing the 'Identifier'-string with 'Observable')
+
+        root_observable_id_candidate = root_observable_id_candidate.replace('indicator','observable')
+        root_observable_id_candidate = root_observable_id_candidate.replace('Indicator','Observable')
+
+        if ('bservable' in root_observable_id_candidate):
+            # If now we have 'Observable' or 'observable' in the identifier, then
+            # we succeeded in deriving an identifier by the replacement carried out above
+            root_observable_id = root_observable_id_candidate
+        else:
+            # Otherwise, we create a new (hopefully unique) ID by preprending 'Observable'
+            root_observable_id = "Observable-%s" % root_observable_id_candidate
         root_observable = Observable()
+        if root_observable_ns:
+            root_observable._id = "%s:%s" % (root_observable_ns,root_observable_id)
+        else:
+            root_observable._id = root_observable_id
         root_observable.observable_composition = observable_composition
 
         return root_observable


### PR DESCRIPTION
Hi,

when an Indicator is created with several Observables in it, the Indicator-object randomly generates an identifier for the Observable required for wrapping a Observable Composition containing the user-specified observables. This identifier cannot be influenced via the API.

This is troublesome, because for certain use cases it is necessary that _all_ identifiers of a STIX entity can be influenced by the user -- at least to the extent that two runs of the code yield exactly the same STIX entity with exactly the same identifiers. (The most obvious use-case is that more than one revisions of a STIX entity are to be generated -- obviously, the identifiers must stay the same.

The code in this pull request gives one possible solution to the problem: the identifier of the root observable is derived from the identifier of the indicator -- thus, several runs of XML-producing code with the same input will always generate the same XML output.

I realize the approach of this derivation is not ideal -- it would be better, if the user could freely specify the id of the root observable via the API, but that would require non-local changes.
