### PR TITLE
fix handling of test mechs

### DIFF
--- a/stix/bindings/indicator.py
+++ b/stix/bindings/indicator.py
@@ -666,24 +666,25 @@ class TestMechanismsType(GeneratedsSuper):
                 if len(type_names_) == 1:
                     type_name_ = type_names_[0]
                 else:
-                    type_name_ = type_names_[1]            
-                    if type_name_ == "OVAL5.10TestMechanismType":
-                        import stix.bindings.extensions.test_mechanism.oval_5_10 as oval_5_10_tm_binding
-                        obj_ = oval_5_10_tm_binding.OVAL5_10TestMechanismType.factory()
-                    elif type_name_ == "YaraTestMechanismType":
-                        import stix.bindings.extensions.test_mechanism.yara as yara_tm_binding
-                        obj_ = yara_tm_binding.YaraTestMechanismType.factory()
-                    elif type_name_ == "SnortTestMechanismType":
-                        import stix.bindings.extensions.test_mechanism.snort as snort_tm_binding
-                        obj_ = snort_tm_binding.SnortTestMechanismType.factory()
-                    elif type_name_ == "OpenIOC2010TestMechanismType":
-                        import stix.bindings.extensions.test_mechanism.open_ioc_2010 as openioc_tm_binding
-                        obj_ = openioc_tm_binding.OpenIOC2010TestMechanismType.factory()
-                    elif type_name_ == "GenericTestMechanismType":
-                        import stix.bindings.extensions.test_mechanism.generic as generic_tm_binding
-                        obj_ = generic_tm_binding.GenericTestMechanismType.factory()
-                    else:
-                        raise NotImplementedError('Class not implemented for <Test_Mechanism> element: ' + type_name_)
+                    type_name_ = type_names_[1]
+                    
+                if type_name_ == "OVAL5.10TestMechanismType":
+                    import stix.bindings.extensions.test_mechanism.oval_5_10 as oval_5_10_tm_binding
+                    obj_ = oval_5_10_tm_binding.OVAL5_10TestMechanismType.factory()
+                elif type_name_ == "YaraTestMechanismType":
+                    import stix.bindings.extensions.test_mechanism.yara as yara_tm_binding
+                    obj_ = yara_tm_binding.YaraTestMechanismType.factory()
+                elif type_name_ == "SnortTestMechanismType":
+                    import stix.bindings.extensions.test_mechanism.snort as snort_tm_binding
+                    obj_ = snort_tm_binding.SnortTestMechanismType.factory()
+                elif type_name_ == "OpenIOC2010TestMechanismType":
+                    import stix.bindings.extensions.test_mechanism.open_ioc_2010 as openioc_tm_binding
+                    obj_ = openioc_tm_binding.OpenIOC2010TestMechanismType.factory()
+                elif type_name_ == "GenericTestMechanismType":
+                    import stix.bindings.extensions.test_mechanism.generic as generic_tm_binding
+                    obj_ = generic_tm_binding.GenericTestMechanismType.factory()
+                else:
+                    raise NotImplementedError('Class not implemented for <Test_Mechanism> element: ' + type_name_)
             else:
                 raise NotImplementedError(
                     'Class not implemented for <Test_Mechanism> element: no xsi:type attribute found')


### PR DESCRIPTION
This allows test mechanisms to be parsed under all circumstances, even if a colon is missing from the type. 
Caused by an indentation mix-up

Repro:

```
#!/usr/bin/env python

from stix.core import STIXPackage
from stix.extensions.test_mechanism.generic_test_mechanism import GenericTestMechanism

    stix_package = STIXPackage.from_xml('bro.xml')

    for indicator in stix_package.indicators:
        print "== INDICATOR =="
        print "Title: " + str(indicator.title);
        print "Description: " + str(indicator.description);


        for tm in indicator.test_mechanisms:
        print tm.description;


```

> File "/home/ubuntu/workspace/stix/bindings/indicator.py", line 691, in buildChildren
> UnboundLocalError: local variable 'obj_' referenced before assignment
