### PR TITLE
Fixed TypeError with copy.deepcopy()

### DIFF
--- a/stix/bindings/__init__.py
+++ b/stix/bindings/__init__.py
@@ -87,6 +87,8 @@ class _FixedOffsetTZ(tzinfo):
     def dst(self, dt):
         return None
 
+    __reduce__ = object.__reduce__
+
 
 class GeneratedsSuper(object):
 
@@ -225,6 +227,8 @@ class GeneratedsSuper(object):
         return input_data
 
     def gds_format_date(self, input_data, input_name=''):
+        if isinstance(input_data, basestring):
+            return input_data
         _svalue = input_data.strftime('%Y-%m-%d')
         if input_data.tzinfo is not None:
             tzoff = input_data.tzinfo.utcoffset(input_data)


### PR DESCRIPTION
This PR addresses a `TypeError` that is raised when calling `copy.deepcopy()` on an object created from parsing an XML source.

Example:
```python
Python 2.7.9 (default, Feb 10 2015, 03:28:08) 
[GCC 4.2.1 Compatible Apple LLVM 6.0 (clang-600.0.56)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from StringIO import StringIO
>>> import copy
>>> from stix.core import STIXPackage
>>> 
>>> stix_xml = STIXPackage().to_xml()  # Create an empty STIX Package XML string
>>> package = STIXPackage.from_xml(StringIO(stix_xml))  # Parse an empty STIX Package
>>> package_copy = copy.deepcopy(package)  # Make a copy of the parsed STIX Package
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/lib/python2.7/copy.py", line 190, in deepcopy
    y = _reconstruct(x, rv, 1, memo)
  File "/usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/lib/python2.7/copy.py", line 334, in _reconstruct
    state = deepcopy(state, memo)
  File "/usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/lib/python2.7/copy.py", line 163, in deepcopy
    y = copier(x, memo)
  File "/usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/lib/python2.7/copy.py", line 257, in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
  File "/usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/lib/python2.7/copy.py", line 190, in deepcopy
    y = _reconstruct(x, rv, 1, memo)
  File "/usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/lib/python2.7/copy.py", line 328, in _reconstruct
    args = deepcopy(args, memo)
  File "/usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/lib/python2.7/copy.py", line 163, in deepcopy
    y = copier(x, memo)
  File "/usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/lib/python2.7/copy.py", line 237, in _deepcopy_tuple
    y.append(deepcopy(a, memo))
  File "/usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/lib/python2.7/copy.py", line 190, in deepcopy
    y = _reconstruct(x, rv, 1, memo)
  File "/usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/lib/python2.7/copy.py", line 329, in _reconstruct
    y = callable(*args)
TypeError: __init__() takes exactly 3 arguments (1 given)
```

This stems from the `_FixedOffsetTZ` class in `stix.bindings` which extends `datetime.tzinfo`, and includes the following `__reduce__` override:

```python
    def __reduce__(self, *args, **kwargs): # real signature unknown
        """ -> (cls, state) """
        pass
```

I looked at the `dateutil.tz.tzutc` class definition and found that they reset the override via:

```python
__reduce__ = object.__reduce__
```

Setting this in `_FixedOffsetTZ` fixed the `deepcopy()` issue.