### PR TITLE
Merge msd_features

### DIFF
--- a/docs/api/coa/coa.rst
+++ b/docs/api/coa/coa.rst
@@ -9,7 +9,7 @@ Classes
 -------
 
 .. autoclass:: CourseOfAction
-	:show-inheritance:
+    :show-inheritance:
 	:members:
 
 .. autoclass:: RelatedCOAs

--- a/docs/api/coa/coa.rst
+++ b/docs/api/coa/coa.rst
@@ -10,8 +10,8 @@ Classes
 
 .. autoclass:: CourseOfAction
     :show-inheritance:
-	:members:
+    :members:
 
 .. autoclass:: RelatedCOAs
-	:show-inheritance:
-	:members:
+    :show-inheritance:
+    :members:

--- a/docs/api/incident/incident.rst
+++ b/docs/api/incident/incident.rst
@@ -9,25 +9,25 @@ Classes
 -------
 
 .. autoclass:: Incident
-	:show-inheritance:
-	:members:
+    :show-inheritance:
+    :members:
 
 .. autoclass:: AttributedThreatActors
-	:show-inheritance:
-	:members:
+    :show-inheritance:
+    :members:
 
 .. autoclass:: LeveragedTTPs
-	:show-inheritance:
-	:members:
+    :show-inheritance:
+    :members:
 
 .. autoclass:: RelatedIndicators
-	:show-inheritance:
-	:members:
+    :show-inheritance:
+    :members:
 
 .. autoclass:: RelatedObservables
-	:show-inheritance:
-	:members:
+    :show-inheritance:
+    :members:
 
 .. autoclass:: RelatedIncidents
-	:show-inheritance:
-	:members:
+    :show-inheritance:
+    :members:

--- a/docs/api/incident/time.rst
+++ b/docs/api/incident/time.rst
@@ -9,5 +9,5 @@ Classes
 -------
 
 .. autoclass:: Time
-	:show-inheritance:
-	:members:
+    :show-inheritance:
+    :members:

--- a/stix/incident/__init__.py
+++ b/stix/incident/__init__.py
@@ -220,6 +220,86 @@ class Incident(stix.BaseCoreComponent):
     def add_coa_taken(self, value):
         self.coa_taken.append(value)
 
+    @property
+    def related_indicators(self):
+        return self._related_indicators
+
+    @related_indicators.setter
+    def related_indicators(self, value):
+        self._set_var(RelatedIndicators, related_indicators=value)
+
+    def add_related_indicator(self, value):
+        """Adds an Related Indicator to the ``related_indicators`` list
+        property of this :class:`Incident`.
+
+        The `indicator` parameter must be an instance of
+        :class:`.RelatedIndicator` or :class:`Indicator`.
+
+        If the `indicator` parameter is ``None``, no item wil be added to the
+        ``related_indicators`` list property.
+
+        Calling this method is the same as calling ``append()`` on the
+        ``related_indicators`` property.
+
+        See Also:
+            The :class:`RelatedIndicators` documentation.
+
+        Note:
+            If the `indicator` parameter is not an instance of
+            :class:`.RelatedIndicator` an attempt will be
+            made to convert it to one.
+
+        Args:
+            indicator: An instance of :class:`Indicator` or
+                :class:`.RelatedIndicator`.
+
+        Raises:
+            ValueError: If the `indicator` parameter cannot be converted into
+                an instance of :class:`.RelatedIndicator`
+
+        """
+        self.related_indicators.append(value)
+
+    @property
+    def related_observables(self):
+        return self._related_observables
+
+    @related_observables.setter
+    def related_observables(self, value):
+        self._set_var(RelatedObservables, related_observables=value)
+
+    def add_related_observable(self, value):
+        """Adds a Related Observable to the ``related_observables`` list
+        property of this :class:`Incident`.
+
+        The `observable` parameter must be an instance of
+        :class:`.RelatedObservable` or :class:`Observable`.
+
+        If the `observable` parameter is ``None``, no item will be added to the
+        ``related_observables`` list property.
+
+        Calling this method is the same as calling ``append()`` on the
+        ``related_observables`` property.
+
+        See Also:
+            The :class:`RelatedObservables` documentation.
+
+        Note:
+            If the `observable` parameter is not an instance of
+            :class:`.RelatedObservable` an attempt will be
+            made to convert it to one.
+
+        Args:
+            observable: An instance of :class:`Observable` or
+                :class:`.RelatedObservable`.
+
+        Raises:
+            ValueError: If the `value` parameter cannot be converted into
+                an instance of :class:`.RelatedObservable`
+
+        """
+        self.related_observables.append(value)
+
     def to_obj(self, return_obj=None, ns_info=None):
         if not return_obj:
             return_obj = self._binding_class()

--- a/stix/incident/time.py
+++ b/stix/incident/time.py
@@ -11,16 +11,21 @@ class Time(stix.Entity):
     _binding_class = _binding.TimeType
     _namespace = "http://stix.mitre.org/Incident-1"
 
-    def __init__(self):
-        self.first_malicious_action = None
-        self.initial_compromise = None
-        self.first_data_exfiltration = None
-        self.incident_discovery = None
-        self.incident_opened = None
-        self.containment_achieved = None
-        self.restoration_achieved = None
-        self.incident_reported = None
-        self.incident_closed = None
+    def __init__(self, first_malicious_action=None, initial_compromise=None,
+                 first_data_exfiltration=None, incident_discovery=None,
+                 incident_opened=None, containment_achieved=None,
+                 restoration_achieved=None, incident_reported=None,
+                 incident_closed=None):
+
+        self.first_malicious_action = first_malicious_action
+        self.initial_compromise = initial_compromise
+        self.first_data_exfiltration = first_data_exfiltration
+        self.incident_discovery = incident_discovery
+        self.incident_opened = incident_opened
+        self.containment_achieved = containment_achieved
+        self.restoration_achieved = restoration_achieved
+        self.incident_reported = incident_reported
+        self.incident_closed = incident_closed
 
     @property
     def first_malicious_action(self):

--- a/stix/test/incident_test.py
+++ b/stix/test/incident_test.py
@@ -465,6 +465,49 @@ class IncidentTest(EntityTestCase, unittest.TestCase):
         xml = s.getvalue()
         self.assertTrue("A Description" in xml, "Description not exported")
 
+    def test_add_related_observable(self):
+        from cybox.core import Observable
+        from stix.common.related import RelatedObservable
+
+        i = self.klass()
+
+        self.assertEqual(0, len(i.related_observables))
+        i.add_related_observable(Observable())
+        self.assertEqual(1, len(i.related_observables))
+
+
+        related = RelatedObservable(Observable())
+        i.add_related_observable(related)
+        self.assertEqual(2, len(i.related_observables))
+
+        # Test that this fails
+        self.assertRaises(
+            ValueError,
+            i.add_related_observable,
+            "THIS SHOULD FAIL"
+        )
+
+    def test_add_related_indicator(self):
+        from stix.indicator import Indicator
+        from stix.common.related import RelatedIndicator
+
+        i = self.klass()
+
+        self.assertEqual(0, len(i.related_indicators))
+        i.add_related_indicator(Indicator())
+        self.assertEqual(1, len(i.related_indicators))
+
+        related = RelatedIndicator(Indicator())
+        i.add_related_indicator(related)
+        self.assertEqual(2, len(i.related_indicators))
+
+        # Test that this fails
+        self.assertRaises(
+            ValueError,
+            i.add_related_indicator,
+            "THIS SHOULD FAIL"
+        )
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
#231 had fallen pretty out of date and was going to be painful to merge so I just opened a new branch and ported over the changes and aligned them with current python-stix property conventions.

* Added unit tests for `add_related_observable()`
* Added unit tests for `add_related_indicator()`
* Fixed copy/paste error in docstrings.