### PR TITLE
Made STIXPackage's version property read-only.

### DIFF
--- a/stix/core/stix_package.py
+++ b/stix/core/stix_package.py
@@ -75,7 +75,7 @@ class STIXPackage(Cached, stix.Entity):
         
         self.id_ = id_ or idgen.create_id("Package")
         self.idref = idref
-        self.version = STIXPackage._version
+        self._version = STIXPackage._version
         self.stix_header = stix_header
         self.campaigns = campaigns
         self.courses_of_action = courses_of_action
@@ -148,15 +148,6 @@ class STIXPackage(Cached, stix.Entity):
 
         """
         return self._version
-
-    @version.setter
-    def version(self, value):
-        if not value:
-            self._version = None
-        else:
-            utils.check_version(self._ALL_VERSIONS, value)
-            self._version = value
-
 
     @property
     def stix_header(self):
@@ -462,7 +453,7 @@ class STIXPackage(Cached, stix.Entity):
 
         # Don't overwrite this unless passed in.
         if obj.version:
-            return_obj.version = obj.version
+            return_obj._version = obj.version
 
         return return_obj
 
@@ -475,7 +466,7 @@ class STIXPackage(Cached, stix.Entity):
         return_obj.id_ = get('id')
         return_obj.idref = get('idref')
         return_obj.timestamp = get('timestamp')
-        return_obj.version = get('version', cls._version)
+        return_obj._version = get('version', cls._version)
         return_obj.stix_header = STIXHeader.from_dict(get('stix_header'))
         return_obj.campaigns = Campaigns.from_dict(get('campaigns'))
         return_obj.courses_of_action = CoursesOfAction.from_dict(get('courses_of_action'))

--- a/stix/test/core/stix_package_test.py
+++ b/stix/test/core/stix_package_test.py
@@ -187,22 +187,6 @@ class STIXPackageTests(EntityTestCase, unittest.TestCase):
         package = core.STIXPackage()
         package.add_related_package(core.STIXPackage(idref='foo'))
 
-    def test_version(self):
-        """Tests that setting the version property of a STIXPackage does
-        not affect the serialized versions.
-
-        """
-        p = core.STIXPackage()
-        p.version = "1.0"  # old version
-
-        s = p.to_xml()
-        sio = StringIO.StringIO(s)
-
-        # Reparse the package
-        p = core.STIXPackage.from_xml(sio)
-
-        self.assertEqual(p.version, core.STIXPackage._version)
-
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
 This induced changes in other methods which tried to set it via the property
descriptor.  Now those methods just set self._version directly.

Also removed a test case for setting STIXPackage versions.  It
is irrelevant if version is read-only.