### PR TITLE
Fix for issue #276

### DIFF
--- a/stix/exploit_target/vulnerability.py
+++ b/stix/exploit_target/vulnerability.py
@@ -189,6 +189,29 @@ class Vulnerability(stix.Entity):
         self._set_var(DateTimeWithPrecision, discovered_datetime=value)
 
     @property
+    def published_datetime(self):
+        """
+        Returns:
+            The time this vulnerability was published, represented as
+            class:`DateTimeWithPrecision`
+        """
+        return self._published_datetime
+
+    @published_datetime.setter
+    def published_datetime(self, value):
+        """
+        Sets the time this vulnerability was published, represented as
+        class:`DateTimeWithPrecision`
+
+        Default Value: ``None``
+
+        Returns:
+            None
+
+        """
+        self._set_var(DateTimeWithPrecision, published_datetime=value)
+
+    @property
     def references(self):
         return self._references
 


### PR DESCRIPTION
Changed the published_datetime field of 
stix.exploit_target.vulnerability.Vulnerability
to be wrapped in a property descriptor, analogously to
discovered_datetime.  I hope this fixes python-stix issue #276.