### PR TITLE
use obj.id_ instead of obj.id

### DIFF
--- a/stix/base.py
+++ b/stix/base.py
@@ -613,6 +613,16 @@ class BaseCoreComponent(Cached, Entity):
             self.idref = None
 
     @property
+    def id(self):
+        """The ``id`` and ``id_`` properties reference the same variable.
+        """
+        return self.id_
+
+    @id.setter
+    def id(self, value):
+        self.id_(value)
+
+    @property
     def idref(self):
         """The ``idref`` property must be set to the ``id_`` value of another
         object instance of the same type. An idref does not need to resolve to

--- a/stix/base.py
+++ b/stix/base.py
@@ -867,7 +867,7 @@ class BaseCoreComponent(Cached, Entity):
         if not obj:
             raise ValueError("Must provide an obj argument")
 
-        return_obj.id_ = obj.id
+        return_obj.id_ = obj.id_
         return_obj.idref = obj.idref
         return_obj.timestamp = obj.timestamp
 

--- a/stix/bindings/course_of_action.py
+++ b/stix/bindings/course_of_action.py
@@ -59,6 +59,11 @@ class StructuredCOAType(GeneratedsSuper):
     def set_idref(self, idref): self.idref = idref
     def get_id(self): return self.id
     def set_id(self, id): self.id = id
+    @property
+    def id_(self): return self.id
+    @id_.setter
+    def id_(self, value):
+        self.set_id(value)
     def hasContent_(self):
         if (
 

--- a/stix/bindings/data_marking.py
+++ b/stix/bindings/data_marking.py
@@ -159,6 +159,11 @@ class MarkingStructureType(GeneratedsSuper):
     def set_marking_model_name(self, marking_model_name): self.marking_model_name = marking_model_name
     def get_id(self): return self.id
     def set_id(self, id): self.id = id
+    @property
+    def id_(self): return self.id
+    @id_.setter
+    def id_(self, value):
+        self.set_id(value)
     def hasContent_(self):
         if (
 
@@ -260,6 +265,11 @@ class MarkingSpecificationType(GeneratedsSuper):
     def set_id(self, id): self.id = id
     def get_version(self): return self.version
     def set_version(self, version): self.version = version
+    @property
+    def id_(self): return self.id
+    @id_.setter
+    def id_(self, value):
+        self.set_id(value)
     def hasContent_(self):
         if (
             self.Controlled_Structure is not None or

--- a/stix/bindings/indicator.py
+++ b/stix/bindings/indicator.py
@@ -245,6 +245,11 @@ class TestMechanismType(GeneratedsSuper):
     def set_id(self, id): self.id = id
     def get_xsi_type(self): return self.xsi_type
     def set_xsi_type(self, xsi_type): self.xsi_type = xsi_type
+    @property
+    def id_(self): return self.id
+    @id_.setter
+    def id_(self, value):
+        self.set_id(value)
     def hasContent_(self):
         if (
             self.Efficacy is not None and

--- a/stix/bindings/stix_common.py
+++ b/stix/bindings/stix_common.py
@@ -934,6 +934,11 @@ class KillChainType(GeneratedsSuper):
     def set_definer(self, definer): self.definer = definer
     def get_name(self): return self.name
     def set_name(self, name): self.name = name
+    @property
+    def id_(self): return self.id
+    @id_.setter
+    def id_(self, value):
+        self.set_id(value)
     def hasContent_(self):
         if (
             self.Kill_Chain_Phase
@@ -1284,6 +1289,11 @@ class IdentityType(GeneratedsSuper):
     def set_idref(self, idref): self.idref = idref
     def get_id(self): return self.id
     def set_id(self, id): self.id = id
+    @property
+    def id_(self): return self.id
+    @id_.setter
+    def id_(self, value):
+        self.set_id(value)
     def hasContent_(self):
         if (
             self.Name is not None or
@@ -2044,6 +2054,11 @@ class IndicatorBaseType(GeneratedsSuper):
     def set_id(self, id): self.id = id
     def get_timestamp(self): return self.timestamp
     def set_timestamp(self, timestamp): self.timestamp = timestamp
+    @property
+    def id_(self): return self.id
+    @id_.setter
+    def id_(self, value):
+        self.set_id(value)
     def hasContent_(self):
         if (
 
@@ -2145,6 +2160,11 @@ class IncidentBaseType(GeneratedsSuper):
     def set_id(self, id): self.id = id
     def get_timestamp(self): return self.timestamp
     def set_timestamp(self, timestamp): self.timestamp = timestamp
+    @property
+    def id_(self): return self.id
+    @id_.setter
+    def id_(self, value):
+        self.set_id(value)
     def hasContent_(self):
         if (
 
@@ -2246,6 +2266,11 @@ class TTPBaseType(GeneratedsSuper):
     def set_id(self, id): self.id = id
     def get_timestamp(self): return self.timestamp
     def set_timestamp(self, timestamp): self.timestamp = timestamp
+    @property
+    def id_(self): return self.id
+    @id_.setter
+    def id_(self, value):
+        self.set_id(value)
     def hasContent_(self):
         if (
 
@@ -2348,6 +2373,11 @@ class ExploitTargetBaseType(GeneratedsSuper):
     def set_id(self, id): self.id = id
     def get_timestamp(self): return self.timestamp
     def set_timestamp(self, timestamp): self.timestamp = timestamp
+    @property
+    def id_(self): return self.id
+    @id_.setter
+    def id_(self, value):
+        self.set_id(value)
     def hasContent_(self):
         if (
 
@@ -2449,6 +2479,11 @@ class CourseOfActionBaseType(GeneratedsSuper):
     def set_id(self, id): self.id = id
     def get_timestamp(self): return self.timestamp
     def set_timestamp(self, timestamp): self.timestamp = timestamp
+    @property
+    def id_(self): return self.id
+    @id_.setter
+    def id_(self, value):
+        self.set_id(value)
     def hasContent_(self):
         if (
 
@@ -2602,6 +2637,11 @@ class CampaignReferenceType(GeneratedsSuper):
     def set_idref(self, idref): self.idref = idref
     def get_timestamp(self): return self.timestamp
     def set_timestamp(self, timestamp): self.timestamp = timestamp
+    @property
+    def id_(self): return self.id
+    @id_.setter
+    def id_(self, value):
+        self.set_id(value)
     def hasContent_(self):
         if (
             self.Names is not None
@@ -2770,6 +2810,11 @@ class CampaignBaseType(GeneratedsSuper):
     def set_id(self, id): self.id = id
     def get_timestamp(self): return self.timestamp
     def set_timestamp(self, timestamp): self.timestamp = timestamp
+    @property
+    def id_(self): return self.id
+    @id_.setter
+    def id_(self, value):
+        self.set_id(value)
     def hasContent_(self):
         if (
 
@@ -2872,6 +2917,11 @@ class ThreatActorBaseType(GeneratedsSuper):
     def set_id(self, id): self.id = id
     def get_timestamp(self): return self.timestamp
     def set_timestamp(self, timestamp): self.timestamp = timestamp
+    @property
+    def id_(self): return self.id
+    @id_.setter
+    def id_(self, value):
+        self.set_id(value)
     def hasContent_(self):
         if (
 
@@ -3480,6 +3530,11 @@ class StructuredTextType(GeneratedsSuper):
     def set_id(self, id): self.id = id
     def get_ordinality(self): return self.ordinality
     def set_ordinality(self, ordinality): self.ordinality = ordinality
+    @property
+    def id_(self): return self.id
+    @id_.setter
+    def id_(self, value):
+        self.set_id(value)
     def hasContent_(self):
         if (
             self.valueOf_
@@ -3763,6 +3818,11 @@ class ReportBaseType(GeneratedsSuper):
     def set_id(self, id): self.id = id
     def get_extensiontype_(self): return self.extensiontype_
     def set_extensiontype_(self, extensiontype_): self.extensiontype_ = extensiontype_
+    @property
+    def id_(self): return self.id
+    @id_.setter
+    def id_(self, value):
+        self.set_id(value)
     def hasContent_(self):
         if (
 

--- a/stix/bindings/stix_core.py
+++ b/stix/bindings/stix_core.py
@@ -87,6 +87,11 @@ class STIXType(GeneratedsSuper):
     def set_version(self, version): self.version = version
     def get_timestamp(self): return self.timestamp
     def set_timestamp(self, timestamp): self.timestamp = timestamp
+    @property
+    def id_(self): return self.id
+    @id_.setter
+    def id_(self, value):
+        self.set_id(value)
     def hasContent_(self):
         if (
             self.STIX_Header is not None or

--- a/stix/bindings/ttp.py
+++ b/stix/bindings/ttp.py
@@ -77,6 +77,11 @@ class AttackPatternType(GeneratedsSuper):
     def set_capec_id(self, capec_id): self.capec_id = capec_id
     def get_id(self): return self.id
     def set_id(self, id): self.id = id
+    @property
+    def id_(self): return self.id
+    @id_.setter
+    def id_(self, value):
+        self.set_id(value)
     def hasContent_(self):
         if (
             self.Title is not None or
@@ -227,6 +232,11 @@ class MalwareInstanceType(GeneratedsSuper):
     def set_idref(self, idref): self.idref = idref
     def get_id(self): return self.id
     def set_id(self, id): self.id = id
+    @property
+    def id_(self): return self.id
+    @id_.setter
+    def id_(self, value):
+        self.set_id(value)
     def hasContent_(self):
         if (
             self.Type or
@@ -362,6 +372,11 @@ class ExploitType(GeneratedsSuper):
     def set_idref(self, idref): self.idref = idref
     def get_id(self): return self.id
     def set_id(self, id): self.id = id
+    @property
+    def id_(self): return self.id
+    @id_.setter
+    def id_(self, value):
+        self.set_id(value)
     def hasContent_(self):
         if (
             self.Title is not None or
@@ -489,6 +504,11 @@ class InfrastructureType(GeneratedsSuper):
     def set_idref(self, idref): self.idref = idref
     def get_id(self): return self.id
     def set_id(self, id): self.id = id
+    @property
+    def id_(self): return self.id
+    @id_.setter
+    def id_(self, value):
+        self.set_id(value)
     def hasContent_(self):
         if (
             self.Title is not None or

--- a/stix/coa/structured_coa.py
+++ b/stix/coa/structured_coa.py
@@ -30,7 +30,7 @@ class _BaseStructuredCOA(Cached, stix.Entity):
             klass = stix.lookup_extension(obj)
             return_obj = klass.from_obj(obj)
         else:
-            return_obj.id_ = obj.id
+            return_obj.id_ = obj.id_
             return_obj.idref = obj.idref
 
         return return_obj

--- a/stix/common/identity.py
+++ b/stix/common/identity.py
@@ -30,6 +30,16 @@ class Identity(Cached, stix.Entity):
         else:
             self._id = value
             self.idref = None
+
+    @property
+    def id(self):
+        """The ``id`` and ``id_`` properties reference the same variable.
+        """
+        return self.id_
+
+    @id.setter
+    def id(self, value):
+        self.id_(value)
     
     @property
     def idref(self):

--- a/stix/common/identity.py
+++ b/stix/common/identity.py
@@ -94,7 +94,7 @@ class Identity(Cached, stix.Entity):
             klass = stix.lookup_extension(obj, default=cls)
             return_obj = klass.from_obj(obj, return_obj=klass())
         else:
-            return_obj.id_ = obj.id
+            return_obj.id_ = obj.id_
             return_obj.idref = obj.idref
             return_obj.name = obj.Name
             return_obj.related_identities = \

--- a/stix/common/kill_chains/__init__.py
+++ b/stix/common/kill_chains/__init__.py
@@ -64,7 +64,7 @@ class KillChain(stix.Entity):
         if not return_obj:
             return_obj = cls()
 
-        return_obj.id_ = obj.id
+        return_obj.id_ = obj.id_
         return_obj.name = obj.name
         return_obj.definer = obj.definer
         return_obj.reference = obj.reference

--- a/stix/common/structured_text.py
+++ b/stix/common/structured_text.py
@@ -115,7 +115,7 @@ class StructuredText(stix.Entity):
         if not return_obj:
             return_obj = cls()
 
-        return_obj.id_ = obj.id
+        return_obj.id_ = obj.id_
         return_obj.value = obj.valueOf_
         return_obj.ordinality = obj.ordinality
         return_obj.structuring_format = obj.structuring_format

--- a/stix/core/stix_package.py
+++ b/stix/core/stix_package.py
@@ -436,7 +436,7 @@ class STIXPackage(Cached, stix.Entity):
         if not return_obj:
             return_obj = cls()
 
-        return_obj.id_ = obj.id
+        return_obj.id_ = obj.id_
         return_obj.idref = obj.idref
         return_obj.timestamp = obj.timestamp
         return_obj.stix_header = STIXHeader.from_obj(obj.STIX_Header)

--- a/stix/core/stix_package.py
+++ b/stix/core/stix_package.py
@@ -106,6 +106,16 @@ class STIXPackage(Cached, stix.Entity):
             self.idref = None
 
     @property
+    def id(self):
+        """The ``id`` and ``id_`` properties reference the same variable.
+        """
+        return self.id_
+
+    @id.setter
+    def id(self, value):
+        self.id_(value)
+
+    @property
     def idref(self):
         """A reference to another Report identifier. Setting this will unset
         any previous ``id`` values.

--- a/stix/data_marking.py
+++ b/stix/data_marking.py
@@ -136,7 +136,7 @@ class MarkingSpecification(Cached, stix.Entity):
         if not return_obj:
             return_obj = cls()
 
-        return_obj.id_ = obj.id
+        return_obj.id_ = obj.id_
         return_obj.idref = obj.idref
         return_obj.version = obj.version
         return_obj.controlled_structure = obj.Controlled_Structure

--- a/stix/indicator/test_mechanism.py
+++ b/stix/indicator/test_mechanism.py
@@ -53,7 +53,7 @@ class _BaseTestMechanism(Cached, stix.Entity):
             klass = stix.lookup_extension(obj)
             return_obj = klass.from_obj(obj)
         else:
-            return_obj.id_ = obj.id
+            return_obj.id_ = obj.id_
             return_obj.idref = obj.idref
             return_obj.efficacy = Statement.from_obj(obj.Efficacy)
             return_obj.producer = InformationSource.from_obj(obj.Producer)

--- a/stix/report/__init__.py
+++ b/stix/report/__init__.py
@@ -97,6 +97,16 @@ class Report(Cached, stix.Entity):
         else:
             self._id = value
             self.idref = None
+
+    @property
+    def id(self):
+        """The ``id`` and ``id_`` properties reference the same variable.
+        """
+        return self.id_
+
+    @id.setter
+    def id(self, value):
+        self.id_(value)
     
     @property
     def idref(self):

--- a/stix/report/__init__.py
+++ b/stix/report/__init__.py
@@ -389,7 +389,7 @@ class Report(Cached, stix.Entity):
             return_obj = cls()
 
         # ReportBaseType fields
-        return_obj.id_ = obj.id
+        return_obj.id_ = obj.id_
         return_obj.idref = obj.idref
         return_obj.timestamp = obj.timestamp
 

--- a/stix/ttp/attack_pattern.py
+++ b/stix/ttp/attack_pattern.py
@@ -50,6 +50,16 @@ class AttackPattern(Cached, stix.Entity):
             self.idref = None
 
     @property
+    def id(self):
+        """The ``id`` and ``id_`` properties reference the same variable.
+        """
+        return self.id_
+
+    @id.setter
+    def id(self, value):
+        self.id_(value)
+
+    @property
     def idref(self):
         """The ``idref`` property must be set to the ``id_`` value of another
         object instance of the same type. An idref does not need to resolve to

--- a/stix/ttp/attack_pattern.py
+++ b/stix/ttp/attack_pattern.py
@@ -225,7 +225,7 @@ class AttackPattern(Cached, stix.Entity):
         if not return_obj:
             return_obj = cls()
 
-        return_obj.id_ = obj.id
+        return_obj.id_ = obj.id_
         return_obj.idref = obj.idref
         return_obj.capec_id = obj.capec_id
         return_obj.title = obj.Title

--- a/stix/ttp/exploit.py
+++ b/stix/ttp/exploit.py
@@ -222,7 +222,7 @@ class Exploit(Cached, stix.Entity):
         if not return_obj:
             return_obj = cls()
 
-        return_obj.id_ = obj.id
+        return_obj.id_ = obj.id_
         return_obj.title = obj.Title
         return_obj.descriptions = StructuredTextList.from_obj(obj.Description)
         return_obj.short_descriptions = StructuredTextList.from_obj(obj.Short_Description)

--- a/stix/ttp/exploit.py
+++ b/stix/ttp/exploit.py
@@ -49,6 +49,16 @@ class Exploit(Cached, stix.Entity):
             self.idref = None
 
     @property
+    def id(self):
+        """The ``id`` and ``id_`` properties reference the same variable.
+        """
+        return self.id_
+
+    @id.setter
+    def id(self, value):
+        self.id_(value)
+
+    @property
     def idref(self):
         """The ``idref`` property must be set to the ``id_`` value of another
         object instance of the same type. An idref does not need to resolve to

--- a/stix/ttp/infrastructure.py
+++ b/stix/ttp/infrastructure.py
@@ -247,7 +247,7 @@ class Infrastructure(Cached, stix.Entity):
         if not return_obj:
             return_obj = cls()
 
-        return_obj.id_ = obj.id
+        return_obj.id_ = obj.id_
         return_obj.title = obj.Title
         return_obj.descriptions = StructuredTextList.from_obj(obj.Description)
         return_obj.short_descriptions = StructuredTextList.from_obj(obj.Short_Description)

--- a/stix/ttp/infrastructure.py
+++ b/stix/ttp/infrastructure.py
@@ -51,6 +51,16 @@ class Infrastructure(Cached, stix.Entity):
             self.idref = None
 
     @property
+    def id(self):
+        """The ``id`` and ``id_`` properties reference the same variable.
+        """
+        return self.id_
+
+    @id.setter
+    def id(self, value):
+        self.id_(value)
+
+    @property
     def idref(self):
         """The ``idref`` property must be set to the ``id_`` value of another
         object instance of the same type. An idref does not need to resolve to

--- a/stix/ttp/malware_instance.py
+++ b/stix/ttp/malware_instance.py
@@ -53,6 +53,16 @@ class MalwareInstance(Cached, stix.Entity):
             self.idref = None
 
     @property
+    def id(self):
+        """The ``id`` and ``id_`` properties reference the same variable.
+        """
+        return self.id_
+
+    @id.setter
+    def id(self, value):
+        self.id_(value)
+
+    @property
     def idref(self):
         """The ``idref`` property must be set to the ``id_`` value of another
         object instance of the same type. An idref does not need to resolve to

--- a/stix/ttp/malware_instance.py
+++ b/stix/ttp/malware_instance.py
@@ -263,7 +263,7 @@ class MalwareInstance(Cached, stix.Entity):
             klass = stix.lookup_extension(obj, default=cls)
             return_obj = klass.from_obj(obj, klass())
         else:
-            return_obj.id_ = obj.id
+            return_obj.id_ = obj.id_
             return_obj.title = obj.Title
             return_obj.descriptions = StructuredTextList.from_obj(obj.Description)
             return_obj.short_descriptions = StructuredTextList.from_obj(obj.Short_Description)


### PR DESCRIPTION
As reported by @nikkiellis during integration testing in chantilly

--
edit: This change [breaks round-tripping](https://travis-ci.org/STIXProject/python-stix/jobs/97744512) - will defer on merging until CI is cleared