### PR TITLE
Parsing MAECInstance from XML

### DIFF
--- a/stix/extensions/malware/maec_4_1_malware.py
+++ b/stix/extensions/malware/maec_4_1_malware.py
@@ -158,7 +158,7 @@ class MAECInstance(MalwareInstance):
         else:
             obj.MAEC = obj.MAEC
 
-        super(MAECInstance, cls).from_obj(obj)
+        return_obj = super(MAECInstance, cls).from_obj(obj)
 
         return return_obj
 
@@ -192,11 +192,11 @@ class MAECInstance(MalwareInstance):
     def from_dict(cls, d, return_obj=None):
         if not d:
             return None
-    
+
         d = d.copy()
-    
+
         maec = d.get('maec')
-    
+
         if maec is None:
             pass
         elif isinstance(maec, dict):
@@ -205,9 +205,9 @@ class MAECInstance(MalwareInstance):
             d['maec'] = mixbox.xml.get_etree_root(BytesIO(maec))
         else:
             raise TypeError("Unknown type for 'maec' entry.")
-    
+
         return_obj = super(MAECInstance, cls).from_dict(d)
-        
+
         return return_obj
 
     def to_dict(self):
@@ -219,13 +219,13 @@ class MAECInstance(MalwareInstance):
                 root = mixbox.xml.get_etree_root(tree)
                 self._parse_etree(root)
                 self.maec = root
-                
+
             if _MAEC_INSTALLED and isinstance(self.maec, maecPackage):
                 d['maec'] = self.maec.to_dict()
             else:
                 d['maec'] = etree.tostring(self.maec)
-                
+
             if self._XSI_TYPE:
                 d['xsi:type'] = self._XSI_TYPE
-                
+
         return d

--- a/stix/test/__init__.py
+++ b/stix/test/__init__.py
@@ -54,6 +54,7 @@ def round_trip_dict(cls, dict_):
     dict2 = cls.to_dict(api_obj)
     return dict2
 
+
 def round_trip(o, output=False, list_=False):
     """ Performs all eight conversions to verify import/export functionality.
 
@@ -124,13 +125,14 @@ def round_trip(o, output=False, list_=False):
     # Before parsing the XML, make sure the cache is clear
     cybox.utils.cache_clear()
 
-    #7. XML String -> Bindings Object
+    # 7. XML String -> Bindings Object
     xobj2 = klass._binding.parseString(xml_string)
 
     # 8. Bindings object -> cybox.Entity
     o3 = klass.from_obj(xobj2)
 
     return o3
+
 
 class EntityTestCase(object):
     """A base class for testing STIX Entities"""
@@ -157,7 +159,6 @@ class EntityTestCase(object):
 
         return dict(items)
 
-
     @silence_warnings
     def test_round_trip_full(self):
         # Don't run this test on the base class
@@ -165,7 +166,6 @@ class EntityTestCase(object):
             return
 
         ent = self.klass.from_dict(self._full_dict)
-        
         ent2 = round_trip(ent, output=True)
 
     @silence_warnings
@@ -190,4 +190,3 @@ class TypedListTestCase(object):
         obj = self.klass.from_dict(self._full_dict)
         dict2 = obj.to_dict()
         self.assertEqual(self._full_dict, dict2)
-

--- a/stix/test/extensions/malware/maec_4_1_malware_test.py
+++ b/stix/test/extensions/malware/maec_4_1_malware_test.py
@@ -115,7 +115,7 @@ class PythonMAECEtreeTests(unittest.TestCase):
 
 
 class PythonMAECInPackageTests(unittest.TestCase):
-    XML = BytesIO(
+    XML = StringIO(
         """
         <stix:STIX_Package 
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -149,7 +149,7 @@ class PythonMAECInPackageTests(unittest.TestCase):
         </stix:STIX_Package>
         """
     )
-    XML_MAEC = BytesIO(
+    XML_MAEC = StringIO(
         """
         <stix:STIX_Package 
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -180,7 +180,6 @@ class PythonMAECInPackageTests(unittest.TestCase):
                     <ttp:Type xsi:type="stixVocabs:MalwareTypeVocab-1.0">Remote Access Trojan</ttp:Type>
                     <ttp:Name>Poison Ivy Variant v4392-acc</ttp:Name>
                     <stix-maec:MAEC id="example:package-2fb96bef-1b11-436e-af4a-15588ac3198b" schema_version="2.1">
-                      <!-- MAEC Content Here -->
                       <maecPackage:Malware_Subjects>
                         <maecPackage:Malware_Subject id="example:Subject-57cd4839-436e-1b11-af4a-15588ac3198b">
                           <maecPackage:Malware_Instance_Object_Attributes>

--- a/stix/test/extensions/malware/maec_4_1_malware_test.py
+++ b/stix/test/extensions/malware/maec_4_1_malware_test.py
@@ -1,4 +1,5 @@
 import unittest
+from stix.core import STIXPackage
 from mixbox.vendor.six import StringIO, BytesIO, text_type
 
 from lxml import etree
@@ -111,6 +112,104 @@ class PythonMAECEtreeTests(unittest.TestCase):
         d = ext.to_dict()
         ext2 = MAECInstance.from_dict(d)
         self._test_xml(ext2)
+
+
+class PythonMAECInPackageTests(unittest.TestCase):
+    XML = BytesIO(
+        """
+        <stix:STIX_Package 
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:stix="http://stix.mitre.org/stix-1"
+            xmlns:stixCommon="http://stix.mitre.org/common-1"
+            xmlns:stixVocabs="http://stix.mitre.org/default_vocabularies-1"
+            xmlns:ttp="http://stix.mitre.org/TTP-1"
+            xmlns:example="http://example.com"
+            xsi:schemaLocation="
+            http://stix.mitre.org/TTP-1 http://stix.mitre.org/XMLSchema/ttp/1.2/ttp.xsd
+            http://stix.mitre.org/common-1 http://stix.mitre.org/XMLSchema/common/1.2/stix_common.xsd
+            http://stix.mitre.org/default_vocabularies-1 http://stix.mitre.org/XMLSchema/default_vocabularies/1.2.0/stix_default_vocabularies.xsd
+            http://stix.mitre.org/stix-1 http://stix.mitre.org/XMLSchema/core/1.2/stix_core.xsd"
+            id="example:Package-2b8fb66f-b6b3-4d40-865a-33e4a5ee1246" 
+            version="1.2"
+            timestamp="2014-05-08T09:00:00.000000Z"
+            >
+          <stix:TTPs>
+            <stix:TTP xsi:type="ttp:TTPType" id="example:ttp-7d9fe1f7-429d-077e-db51-92c70b8da45a">
+              <ttp:Title>Poison Ivy Variant v4392-acc</ttp:Title>
+              <ttp:Behavior>
+                <ttp:Malware>
+                  <ttp:Malware_Instance>
+                    <ttp:Type xsi:type="stixVocabs:MalwareTypeVocab-1.0">Remote Access Trojan</ttp:Type>
+                    <ttp:Name>Poison Ivy Variant v4392-acc</ttp:Name>
+                  </ttp:Malware_Instance>
+                </ttp:Malware>
+              </ttp:Behavior>
+            </stix:TTP>
+          </stix:TTPs>
+        </stix:STIX_Package>
+        """
+    )
+    XML_MAEC = BytesIO(
+        """
+        <stix:STIX_Package 
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:stix="http://stix.mitre.org/stix-1"
+            xmlns:stixCommon="http://stix.mitre.org/common-1"
+            xmlns:stixVocabs="http://stix.mitre.org/default_vocabularies-1"
+            xmlns:ttp="http://stix.mitre.org/TTP-1"
+            xmlns:stix-maec="http://stix.mitre.org/extensions/Malware#MAEC4.1-1"
+            xmlns:maecPackage="http://maec.mitre.org/XMLSchema/maec-package-2"
+            xmlns:example="http://example.com"
+            xsi:schemaLocation="
+            http://stix.mitre.org/TTP-1 http://stix.mitre.org/XMLSchema/ttp/1.2/ttp.xsd
+            http://stix.mitre.org/common-1 http://stix.mitre.org/XMLSchema/common/1.2/stix_common.xsd
+            http://stix.mitre.org/default_vocabularies-1 http://stix.mitre.org/XMLSchema/default_vocabularies/1.2.0/stix_default_vocabularies.xsd
+            http://stix.mitre.org/stix-1 http://stix.mitre.org/XMLSchema/core/1.2/stix_core.xsd
+            http://stix.mitre.org/extensions/Malware#MAEC4.1-1 http://stix.mitre.org/XMLSchema/extensions/malware/maec_4.1/1.0/maec_4.1_malware.xsd
+            http://maec.mitre.org/XMLSchema/maec-package-2 http://maec.mitre.org/language/version4.1/maec_package_schema.xsd"
+            id="example:Package-2b8fb66f-b6b3-4d40-865a-33e4a5ee1246" 
+            version="1.2"
+            timestamp="2014-05-08T09:00:00.000000Z"
+            >
+          <stix:TTPs>
+            <stix:TTP xsi:type="ttp:TTPType" id="example:ttp-7d9fe1f7-429d-077e-db51-92c70b8da45a">
+              <ttp:Title>Poison Ivy Variant v4392-acc</ttp:Title>
+              <ttp:Behavior>
+                <ttp:Malware>
+                  <ttp:Malware_Instance xsi:type="stix-maec:MAEC4.1InstanceType">
+                    <ttp:Type xsi:type="stixVocabs:MalwareTypeVocab-1.0">Remote Access Trojan</ttp:Type>
+                    <ttp:Name>Poison Ivy Variant v4392-acc</ttp:Name>
+                    <stix-maec:MAEC id="example:package-2fb96bef-1b11-436e-af4a-15588ac3198b" schema_version="2.1">
+                      <!-- MAEC Content Here -->
+                      <maecPackage:Malware_Subjects>
+                        <maecPackage:Malware_Subject id="example:Subject-57cd4839-436e-1b11-af4a-15588ac3198b">
+                          <maecPackage:Malware_Instance_Object_Attributes>
+                          </maecPackage:Malware_Instance_Object_Attributes>
+                        </maecPackage:Malware_Subject>
+                      </maecPackage:Malware_Subjects>
+                    </stix-maec:MAEC>
+                  </ttp:Malware_Instance>
+                </ttp:Malware>
+              </ttp:Behavior>
+            </stix:TTP>
+          </stix:TTPs>
+        </stix:STIX_Package>
+        """
+    )
+
+    def test_parse_malware(self):
+        """Test parsing a normal MalwareInstance from XML
+        """
+        stix_pkg = STIXPackage.from_xml(self.XML)
+        mw = stix_pkg.ttps[0].behavior.malware_instances[0].to_dict()
+        self.assertTrue('names' in mw)
+
+    def test_parse_malware_maec(self):
+        """Test parsing a MaecInstance from XML
+        """
+        stix_pkg = STIXPackage.from_xml(self.XML_MAEC)
+        mw = stix_pkg.ttps[0].behavior.malware_instances[0].to_dict()
+        self.assertTrue('names' in mw)
 
 
 if __name__ == "__main__":

--- a/stix/ttp/malware_instance.py
+++ b/stix/ttp/malware_instance.py
@@ -91,7 +91,7 @@ class MalwareInstance(stix.Entity):
         This is the same as calling "foo.short_descriptions.add(bar)".
         """
         self.short_descriptions.add(description)
-        
+
     def add_name(self, name):
         self.names.append(name)
 


### PR DESCRIPTION
Malware_Instances using the MAEC4.1InstanceType are still not getting parsed from XML correctly.