### PR TITLE
Change stix.ToolInformation and tests for MAEC (STIX 1.2.0.X)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "3.3"
   - "3.4"

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -10,7 +10,7 @@ This page gives an introduction to **python-stix** and how to use it.
 Prerequisites
 -------------
 
-The python-stix library provides an API for creating or processing STIX content. As such, it is a developer tool that can be leveraged by those who know Python 2.6/2.7 and are familiar with object-oriented programming practices, Python package layouts, and are comfortable with the installation of Python libraries. To contribute code to the python-stix repository, users must be familiar with `git`_ and `GitHub pull request`_ methodologies. Understanding XML, XML Schema, and the STIX language is also incredibly helpful when using python-stix in an application.
+The python-stix library provides an API for creating or processing STIX content. As such, it is a developer tool that can be leveraged by those who know Python 2.7/3.3+ and are familiar with object-oriented programming practices, Python package layouts, and are comfortable with the installation of Python libraries. To contribute code to the python-stix repository, users must be familiar with `git`_ and `GitHub pull request`_ methodologies. Understanding XML, XML Schema, and the STIX language is also incredibly helpful when using python-stix in an application.
 
 .. _git: http://git-scm.com/documentation
 .. _GitHub pull request: https://help.github.com/articles/using-pull-requests

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open('README.rst') as f:
 install_requires = [
     'lxml>=2.3',
     'python-dateutil',
-    'cybox>=2.1.0.13.dev1,<2.1.1.0',
+    'cybox>=2.1.0.13,<2.1.1.0',
     'mixbox>=1.0.2',
 ]
 
@@ -48,7 +48,6 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',

--- a/stix/common/tools.py
+++ b/stix/common/tools.py
@@ -3,7 +3,9 @@
 
 # external
 from mixbox import fields
+
 import cybox.common
+from cybox.common.vocabs import VocabField
 
 # internal
 import stix
@@ -11,6 +13,7 @@ import stix.bindings.stix_common as common_binding
 
 # relative
 from .structured_text import StructuredTextList
+from .vocabs import AttackerToolType
 
 
 class ToolInformation(stix.Entity, cybox.common.ToolInformation):
@@ -20,6 +23,7 @@ class ToolInformation(stix.Entity, cybox.common.ToolInformation):
 
     title = fields.TypedField("Title")
     short_descriptions = fields.TypedField("Short_Description", StructuredTextList)
+    type_ = VocabField("Type", AttackerToolType, multiple=True)
 
     def __init__(self, title=None, short_description=None, tool_name=None, tool_vendor=None):
         super(ToolInformation, self).__init__(tool_name=tool_name, tool_vendor=tool_vendor)

--- a/stix/common/vocabs.py
+++ b/stix/common/vocabs.py
@@ -5,9 +5,10 @@
 from functools import partial
 
 # mixbox
-from mixbox import fields
-from mixbox import entities
-from mixbox import typedlist
+from mixbox import entities, fields, typedlist
+
+# cybox
+from cybox.common import vocabs
 
 # stix
 import stix
@@ -24,7 +25,7 @@ def validate_value(instance, value):
     elif value in allowed:
         return
     else:
-        error = "Value must be one of {allowed}. Received '{value}'"
+        error = "Value for vocab {instance.__class__} must be one of {allowed}. Received '{value}'"
         error = error.format(**locals())
         raise ValueError(error)
 
@@ -123,7 +124,6 @@ class VocabString(stix.Entity):
         if self.is_plain():
             return self.value
         return super(VocabString, self).to_dict()
-
 
     @classmethod
     def from_dict(cls, cls_dict):
@@ -306,8 +306,9 @@ class DiscoveryMethod_2_0(VocabString):
     TERM_USER = "User"
 
 
+@vocabs.register_vocab
 @register_vocab
-class AttackerToolType_1_0(VocabString):
+class AttackerToolType_1_0(vocabs.VocabString):
     _namespace = 'http://stix.mitre.org/default_vocabularies-1'
     _XSI_TYPE = 'stixVocabs:AttackerToolTypeVocab-1.0'
     _VOCAB_VERSION = '1.0'

--- a/stix/incident/history.py
+++ b/stix/incident/history.py
@@ -1,22 +1,23 @@
 # Copyright (c) 2017, The MITRE Corporation. All rights reserved.
 # See LICENSE.txt for complete terms.
 
+from mixbox import fields
+
 # internal
 import stix
-import stix.utils as utils
 import stix.bindings.incident as incident_binding
 from stix.common.datetimewithprecision import DATETIME_PRECISION_VALUES
 
 # relative
 from .coa import COATaken
 
-from mixbox import fields, entities
 
 def validate_precision(instance, value):
     if value and (value not in DATETIME_PRECISION_VALUES):
         error = "time_precision must be one of {0}. Received '{1}'"
         error = error.format(DATETIME_PRECISION_VALUES, value)
         raise ValueError(error)
+
 
 class JournalEntry(stix.Entity):
     _namespace = "http://stix.mitre.org/Incident-1"
@@ -25,7 +26,7 @@ class JournalEntry(stix.Entity):
     
     value = fields.TypedField("valueOf_", key_name="value")
     author = fields.TypedField("author")
-    time = fields.TypedField("time")     #TDOO: utils.dates.parse_value(value)
+    time = fields.DateTimeField("time")
     time_precision = fields.TypedField("time_precision", preset_hook=validate_precision)
     
     def __init__(self, value=None):
@@ -38,10 +39,10 @@ class HistoryItem(stix.Entity):
     _namespace = "http://stix.mitre.org/Incident-1"
     _binding = incident_binding
     _binding_class = incident_binding.HistoryItemType
-    
+
     action_entry = fields.TypedField("Action_Entry", COATaken)
     journal_entry = fields.TypedField("Journal_Entry", JournalEntry)
-    
+
     def __init__(self):
         super(HistoryItem, self).__init__()
 
@@ -52,8 +53,7 @@ class History(stix.EntityList):
     _binding_class = incident_binding.HistoryType
 
     history_items = fields.TypedField("History_Item", HistoryItem, multiple=True, key_name="history_items")
-    
+
     @classmethod
     def _dict_as_list(cls):
         return False
-    

--- a/stix/report/__init__.py
+++ b/stix/report/__init__.py
@@ -43,7 +43,7 @@ class Report(stix.Entity):
             ``datetime.datetime`` or ``str``.
         header: A Report :class:`.Header` object.
         campaigns: A collection of :class:`.Campaign` objects.
-        course_of_action: A collection of :class:`.CourseOfAction` objects.
+        courses_of_action: A collection of :class:`.CourseOfAction` objects.
         exploit_targets: A collection of :class:`.ExploitTarget` objects.
         incidents: A collection of :class:`.Incident` objects.
         indicators: A collection of :class:`.Indicator` objects.
@@ -59,7 +59,7 @@ class Report(stix.Entity):
 
     id_ = fields.IdField("id")
     idref = fields.IdrefField("idref")
-    timestamp = fields.TypedField("timestamp")
+    timestamp = fields.DateTimeField("timestamp")
     version = fields.TypedField("version")
     header = fields.TypedField("Header", Header)
     campaigns = fields.TypedField("Campaigns", type_="stix.report.Campaigns")

--- a/stix/test/extensions/malware/maec_4_1_malware_test.py
+++ b/stix/test/extensions/malware/maec_4_1_malware_test.py
@@ -12,7 +12,7 @@ except ImportError:
     maec_present = False
 
 
-@unittest.skipIf(condition=maec_present, reason="These tests require the 'maec' library.")
+@unittest.skipIf(condition=maec_present is True, reason="These tests require the 'maec' library.")
 class PythonMAECTests(EntityTestCase, unittest.TestCase):
     klass = MAECInstance
 
@@ -21,18 +21,20 @@ class PythonMAECTests(EntityTestCase, unittest.TestCase):
         'maec': {
             'malware_subjects':
                 [
-                    {'malware_instance_object_attributes':
-                         {'id': 'maec-tst-obj-1',
-                          'properties': {
-                              'hashes':
-                                  [
-                                      {
-                                          'simple_hash_value': '9d7006e30fdf15e9c8e03e62534b3a3e',
-                                          'type': 'MD5'
-                                      }
-                                  ],
-                              'xsi:type': 'FileObjectType'}
-                         }
+                    {
+                        'malware_instance_object_attributes': {
+                            'id': 'maec-tst-obj-1',
+                            'properties': {
+                                'hashes':
+                                    [
+                                        {
+                                            'simple_hash_value': '9d7006e30fdf15e9c8e03e62534b3a3e',
+                                            'type': 'MD5'
+                                        }
+                                    ],
+                                'xsi:type': 'FileObjectType'
+                            }
+                        }
                     }
                 ]
         }
@@ -47,7 +49,7 @@ class PythonMAECTests(EntityTestCase, unittest.TestCase):
         self.assertTrue("Remote Access Trojan" in maec_xml)
 
 
-@unittest.skipIf(condition=maec_present, reason="These tests require the 'maec' library.")
+@unittest.skipIf(condition=maec_present is True, reason="These tests require the 'maec' library.")
 class PythonMAECInPackageTests(unittest.TestCase):
     XML = StringIO(
         """
@@ -143,7 +145,7 @@ class PythonMAECInPackageTests(unittest.TestCase):
         self.assertTrue('names' in mw)
 
 
-@unittest.skipIf(condition=not maec_present, reason="These tests require the 'maec' library.")
+@unittest.skipIf(condition=maec_present is False, reason="These tests require the 'maec' library to be missing.")
 class PythonMAECNotInstalledTest(unittest.TestCase):
 
     def test_parsing_maec_fails(self):

--- a/stix/test/extensions/malware/maec_4_1_malware_test.py
+++ b/stix/test/extensions/malware/maec_4_1_malware_test.py
@@ -12,7 +12,7 @@ except ImportError:
     maec_present = False
 
 
-@unittest.skipIf(condition=maec_present is True, reason="These tests require the 'maec' library.")
+@unittest.skipIf(condition=maec_present is False, reason="These tests require the 'maec' library.")
 class PythonMAECTests(EntityTestCase, unittest.TestCase):
     klass = MAECInstance
 
@@ -49,7 +49,7 @@ class PythonMAECTests(EntityTestCase, unittest.TestCase):
         self.assertTrue("Remote Access Trojan" in maec_xml)
 
 
-@unittest.skipIf(condition=maec_present is True, reason="These tests require the 'maec' library.")
+@unittest.skipIf(condition=maec_present is False, reason="These tests require the 'maec' library.")
 class PythonMAECInPackageTests(unittest.TestCase):
     XML = StringIO(
         """
@@ -145,7 +145,7 @@ class PythonMAECInPackageTests(unittest.TestCase):
         self.assertTrue('names' in mw)
 
 
-@unittest.skipIf(condition=maec_present is False, reason="These tests require the 'maec' library to be missing.")
+@unittest.skipIf(condition=maec_present is True, reason="These tests require the 'maec' library to be missing.")
 class PythonMAECNotInstalledTest(unittest.TestCase):
 
     def test_parsing_maec_fails(self):

--- a/stix/test/extensions/malware/maec_4_1_malware_test.py
+++ b/stix/test/extensions/malware/maec_4_1_malware_test.py
@@ -152,20 +152,20 @@ class PythonMAECNotInstalledTest(unittest.TestCase):
         try:
             STIXPackage.from_xml(PythonMAECInPackageTests.XML_MAEC)
         except ImportError as e:
-            self.assertEqual(str(e), "No module named 'maec'")
+            self.assertTrue(all(x in str(e) for x in ("No module named", "maec")))
 
     def test_handling_maec_object_fails(self):
         try:
             MAECInstance().from_dict(PythonMAECTests._full_dict)
         except ImportError as e:
-            self.assertEqual(str(e), "No module named 'maec'")
+            self.assertTrue(all(x in str(e) for x in ("No module named", "maec")))
 
     def test_setting_maec_property_fails(self):
         try:
             m = MAECInstance()
             m.maec = "foo"
         except ImportError as e:
-            self.assertEqual(str(e), "No module named 'maec'")
+            self.assertTrue(all(x in str(e) for x in ("No module named", "maec")))
 
 
 if __name__ == "__main__":

--- a/stix/test/extensions/malware/maec_4_1_malware_test.py
+++ b/stix/test/extensions/malware/maec_4_1_malware_test.py
@@ -1,14 +1,18 @@
 import unittest
 from stix.core import STIXPackage
-from mixbox.vendor.six import StringIO, BytesIO, text_type
-
-from lxml import etree
-import mixbox.xml
+from mixbox.vendor.six import StringIO, text_type
 
 from stix.test import EntityTestCase
 from stix.extensions.malware.maec_4_1_malware import MAECInstance
 
+try:
+    import maec
+    maec_present = True
+except ImportError:
+    maec_present = False
 
+
+@unittest.skipIf(condition=maec_present, reason="These tests require the 'maec' library.")
 class PythonMAECTests(EntityTestCase, unittest.TestCase):
     klass = MAECInstance
 
@@ -43,6 +47,7 @@ class PythonMAECTests(EntityTestCase, unittest.TestCase):
         self.assertTrue("Remote Access Trojan" in maec_xml)
 
 
+@unittest.skipIf(condition=maec_present, reason="These tests require the 'maec' library.")
 class PythonMAECInPackageTests(unittest.TestCase):
     XML = StringIO(
         """
@@ -136,6 +141,29 @@ class PythonMAECInPackageTests(unittest.TestCase):
         stix_pkg = STIXPackage.from_xml(self.XML_MAEC)
         mw = stix_pkg.ttps[0].behavior.malware_instances[0].to_dict()
         self.assertTrue('names' in mw)
+
+
+@unittest.skipIf(condition=not maec_present, reason="These tests require the 'maec' library.")
+class PythonMAECNotInstalledTest(unittest.TestCase):
+
+    def test_parsing_maec_fails(self):
+        try:
+            STIXPackage.from_xml(PythonMAECInPackageTests.XML_MAEC)
+        except ImportError as e:
+            self.assertEqual(str(e), "No module named 'maec'")
+
+    def test_handling_maec_object_fails(self):
+        try:
+            MAECInstance().from_dict(PythonMAECTests._full_dict)
+        except ImportError as e:
+            self.assertEqual(str(e), "No module named 'maec'")
+
+    def test_setting_maec_property_fails(self):
+        try:
+            m = MAECInstance()
+            m.maec = "foo"
+        except ImportError as e:
+            self.assertEqual(str(e), "No module named 'maec'")
 
 
 if __name__ == "__main__":

--- a/stix/test/ttp_test.py
+++ b/stix/test/ttp_test.py
@@ -71,7 +71,13 @@ class ResourcesTests(EntityTestCase, unittest.TestCase):
         'personas': PersonasTests._full_dict,
         'tools':  [
             {
-                'title': "Tool"
+                'title': "Tool",
+                'type': [
+                    {
+                        'value': 'Malware',
+                        'xsi:type': 'stixVocabs:AttackerToolTypeVocab-1.0'
+                    }
+                ]
             }
         ],
         'infrastructure': InfrastructureTests._full_dict
@@ -81,7 +87,7 @@ class ResourcesTests(EntityTestCase, unittest.TestCase):
 class MalwareInstanceTests(EntityTestCase, unittest.TestCase):
     klass = malware_instance.MalwareInstance
 
-    _full_dict =  _full_dict = {
+    _full_dict = {
         'id': 'example:test-1',
         'title': 'Title',
         'description': 'Description',
@@ -155,6 +161,7 @@ class BehaviorTests(EntityTestCase, unittest.TestCase):
         'exploits': ExploitsTests._full_dict,
         'attack_patterns': AttackPatternsTests._full_dict
     }
+
 
 class TTPTests(EntityTestCase, unittest.TestCase):
     klass = ttp.TTP

--- a/stix/ttp/resource.py
+++ b/stix/ttp/resource.py
@@ -2,19 +2,15 @@
 # See LICENSE.txt for complete terms.
 
 # mixbox
-from mixbox import fields
-from mixbox import typedlist
+from mixbox import fields, typedlist
 
 # internal
 import stix
+import stix.bindings.ttp as ttp_binding
 from stix.common import ToolInformation
 from stix.common.identity import Identity, IdentityFactory
-import stix.bindings.ttp as ttp_binding
+from stix.ttp.infrastructure import Infrastructure
 
-# relative
-from .infrastructure import Infrastructure
-
-from mixbox import entities, fields
 
 class _IdentityList(typedlist.TypedList):
     def __init__(self, *args):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py33, py34, py35, py36, lxml23
+envlist = py26, py27, py33, py34, py35, py36, lxml23, no-maec
 
 [testenv]
 commands =
@@ -22,11 +22,19 @@ deps =
     python-dateutil==1.4.1
     -rrequirements.txt
 
+# Test the behavior when MAEC is not installed in the environment.
+[testenv:no-maec]
+commands =
+    nosetests stix
+deps =
+    nose==1.3.7
+    tox==2.7.0
+
 [travis]
 python =
-  2.6: py26, lxml23
-  2.7: py27, docs
-  3.3: py33
-  3.4: py34
-  3.5: py35
-  3.6: py36
+  2.6: py26, lxml23, no-maec
+  2.7: py27, docs, no-maec
+  3.3: py33, no-maec
+  3.4: py34, no-maec
+  3.5: py35, no-maec
+  3.6: py36, no-maec

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py33, py34, py35, py36, lxml23, no-maec
+envlist = py27, py33, py34, py35, py36, lxml23, no-maec
 
 [testenv]
 commands =
@@ -13,7 +13,7 @@ deps =
 # We call this "lxml23" instead of "rhel6", since RHEL6 ships with LXML 2.2.3.
 # python-stix requires at least 2.3.
 [testenv:lxml23]
-basepython=python2.6
+basepython=python2.7
 commands =
     nosetests stix
 deps =
@@ -32,8 +32,7 @@ deps =
 
 [travis]
 python =
-  2.6: py26, lxml23, no-maec
-  2.7: py27, docs, no-maec
+  2.7: py27, docs, lxml23, no-maec
   3.3: py33, no-maec
   3.4: py34, no-maec
   3.5: py35, no-maec


### PR DESCRIPTION
This PR is related to CybOXProject/python-cybox#310. It overrides the ToolInformation vocab to AttackerToolType. The build is failing because it needs a release of the latest `cybox` changes related to the vocab fixes. In addition:

- MAEC tests for library present/missing.