### PR TITLE
update project requirements, test harness and small RST fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
 language: python
+sudo: false   # Since this is an older project, this is not the default.
+cache: pip
+dist: xenial
 python:
   - "2.7"
   - "3.4"
   - "3.5"
   - "3.6"
 install:
+  - pip install -U pip setuptools
   - pip install tox-travis
 script:
   - tox

--- a/docs/api/indicator/indicator.rst
+++ b/docs/api/indicator/indicator.rst
@@ -29,7 +29,7 @@ Classes
         add_short_description, add_test_mechanism, add_valid_time_position,
         alternative_id, confidence, description, descriptions, find,
         get_produced_time, get_received_time, handling, id_, idref,
-        indicated_ttps, indicator_types, information_source, kill_chain_phases,
+        indicated_ttps, indicator_types, kill_chain_phases,
         likely_impact, negate, observable, observable_composition_operator,
         observables, producer, related_campaigns, related_indicators,
         related_packages, set_produced_time, set_producer_identity,

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ from setuptools import setup, find_packages
 BASE_DIR = dirname(abspath(__file__))
 VERSION_FILE = join(BASE_DIR, 'stix', 'version.py')
 
+
 def get_version():
     with open(VERSION_FILE) as f:
         for line in f.readlines():
@@ -20,15 +21,17 @@ def get_version():
         raise AttributeError("Package does not have a __version__")
 
 
-with open('README.rst') as f:
-    readme = f.read()
+def get_long_description():
+    with open('README.rst') as f:
+        return f.read()
 
 
 install_requires = [
-    'lxml>=2.3',
-    'python-dateutil',
-    'cybox>=2.1.0.13,<2.1.1.0',
+    'lxml>=2.2.3 ; python_version == "2.7" or python_version >= "3.5"',
+    'lxml>=2.2.3,<4.4.0 ; python_version > "2.7" and python_version < "3.5"',
     'mixbox>=1.0.2',
+    'cybox>=2.1.0.13,<2.1.1.0',
+    'python-dateutil',
 ]
 
 
@@ -38,7 +41,7 @@ setup(
     author="STIX Project, MITRE Corporation",
     author_email="stix@mitre.org",
     description="An API for parsing and generating STIX content.",
-    long_description=readme,
+    long_description=get_long_description(),
     url="http://stix.mitre.org",
     packages=find_packages(),
     install_requires=install_requires,
@@ -50,7 +53,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,11 @@
 [tox]
-envlist = py27, py34, py35, py36, lxml23, no-maec
+envlist = py27, py34, py35, py36, lxml23, docs, no-maec
 
 [testenv]
 commands =
     nosetests stix
     # NOTE: python-stix does not have any doctests
     # sphinx-build -b doctest docs docs/_build/doctest
-    sphinx-build -b html docs docs/_build/html
 deps =
     -rrequirements.txt
 
@@ -29,6 +28,10 @@ commands =
 deps =
     nose==1.3.7
     tox==2.7.0
+
+[testenv:docs]
+commands =
+    sphinx-build -W -b html -d {envtmpdir}/doctrees docs {envtmpdir}/html
 
 [travis]
 python =


### PR DESCRIPTION
- Removes Python 2.6 from Travis CI harness.
- Update project requirements and tox settings.
- Small fix on the RST