### PR TITLE
stix1.1.1 update project requirements, test harness

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
 language: python
+sudo: false   # Since this is an older project, this is not the default.
+cache: pip
+dist: xenial
 python:
   - "2.7"
   - "3.4"
   - "3.5"
   - "3.6"
 install:
+  - pip install -U pip setuptools
   - pip install tox-travis
 script:
   - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
 install:
   - pip install -U pip setuptools
   - pip install tox-travis

--- a/setup.py
+++ b/setup.py
@@ -21,12 +21,14 @@ def get_version():
         raise AttributeError("Package does not have a __version__")
 
 
-with open('README.rst') as f:
-    readme = f.read()
+def get_long_description():
+    with open('README.rst') as f:
+        return f.read()
 
 
 install_requires = [
-    'lxml>=2.3',
+    'lxml>=2.2.3 ; python_version == "2.7" or python_version >= "3.5"',
+    'lxml>=2.2.3,<4.4.0 ; python_version > "2.7" and python_version < "3.5"',
     'python-dateutil',
     'cybox>=2.1.0.13,<2.1.1.0',
     'mixbox>=1.0.2',
@@ -39,7 +41,7 @@ setup(
     author="STIX Project, MITRE Corporation",
     author_email="stix@mitre.org",
     description="An API for parsing and generating STIX content.",
-    long_description=readme,
+    long_description=get_long_description(),
     url="http://stix.mitre.org",
     packages=find_packages(),
     install_requires=install_requires,
@@ -51,7 +53,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34, py35, py36, lxml23, docs, no-maec
+envlist = py27, py34, py35, py36, py37, lxml23, docs, no-maec
 
 [testenv]
 commands =
@@ -39,3 +39,4 @@ python =
   3.4: py34, no-maec
   3.5: py35, no-maec
   3.6: py36, no-maec
+  3.7: py36, no-maec

--- a/tox.ini
+++ b/tox.ini
@@ -39,4 +39,4 @@ python =
   3.4: py34, no-maec
   3.5: py35, no-maec
   3.6: py36, no-maec
-  3.7: py36, no-maec
+  3.7: py37, no-maec

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,11 @@
 [tox]
-envlist = py27, py34, py35, py36, lxml23, no-maec
+envlist = py27, py34, py35, py36, lxml23, docs, no-maec
 
 [testenv]
 commands =
     nosetests stix
     # NOTE: python-stix does not have any doctests
     # sphinx-build -b doctest docs docs/_build/doctest
-    sphinx-build -b html docs docs/_build/html
 deps =
     -rrequirements.txt
 
@@ -29,6 +28,10 @@ commands =
 deps =
     nose==1.3.7
     tox==2.7.0
+
+[testenv:docs]
+commands =
+    sphinx-build -W -b html -d {envtmpdir}/doctrees docs {envtmpdir}/html
 
 [travis]
 python =


### PR DESCRIPTION
Same changes for 1.1.1

- Removes Python 2.6 from Travis CI harness.
- Update project requirements and tox settings.