### PR TITLE
docs: Fix a few typos

### DIFF
--- a/examples/vuln_affected_software.py
+++ b/examples/vuln_affected_software.py
@@ -28,7 +28,7 @@ software.edition = "GOTY"
 # Wrap the Product Object in an Observable instance
 observable = Observable(software)
 
-# Attach the Product observable to the affected_sofware list of
+# Attach the Product observable to the affected_software list of
 # RelatedObservable instances. This wraps our Observable in a
 # RelatedObservable layer.
 vuln = Vulnerability()

--- a/stix/bindings/stix_common.py
+++ b/stix/bindings/stix_common.py
@@ -3495,7 +3495,7 @@ class StructuredTextType(GeneratedsSuper):
     Note that if the markup tags used by this format would be interpreted 
     as XML information (such as the bracket-based tags of HTML) the text 
     area should be enclosed in a CDATA section to prevent the markup from 
-    interferring with XMLvalidation of the CybOX document. If this 
+    interfering with XMLvalidation of the CybOX document. If this 
     attribute is absent, the implication is that no markup is being used."""
     subclass = None
     superclass = None

--- a/stix/common/structured_text.py
+++ b/stix/common/structured_text.py
@@ -64,7 +64,7 @@ class StructuredText(stix.Entity):
         """Converts this object into a dictionary representation.
 
         Note:
-            If no properies or attributes are set other than ``value``,
+            If no properties or attributes are set other than ``value``,
             this will return a string.
 
         """
@@ -95,7 +95,7 @@ def _unset_default(text):
     """Unsets the ordinality of the StructuredText object `text` if the
     ordinality is equal to the DEFAULT_ORDINALITY.
 
-    The ordinaity will be returned to its original state after exiting the
+    The ordinality will be returned to its original state after exiting the
     context manager.
 
     """

--- a/stix/indicator/indicator.py
+++ b/stix/indicator/indicator.py
@@ -470,7 +470,7 @@ class Indicator(stix.BaseCoreComponent):
         ``related_indicators`` list property.
 
         Calling this method is the same as calling ``append()`` on the
-        ``related_indicators`` proeprty.
+        ``related_indicators`` property.
 
         See Also:
             The :class:`RelatedIndicators` documentation.


### PR DESCRIPTION
There are small typos in:
- examples/vuln_affected_software.py
- stix/bindings/stix_common.py
- stix/common/structured_text.py
- stix/indicator/indicator.py

Fixes:
- Should read `software` rather than `sofware`.
- Should read `property` rather than `proeprty`.
- Should read `properties` rather than `properies`.
- Should read `ordinality` rather than `ordinaity`.
- Should read `interfering` rather than `interferring`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md